### PR TITLE
[SHIPA-2139] enforce unit test coverage

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,12 +14,22 @@ jobs:
         with:
           go-version: '1.17'
       - name: Unit Tests
-        run : |
+        run: |
           make install-kubebuilder KUBEBUILDER_INSTALL_DIR=/tmp/kubebuilder
           export TEST_ASSET_KUBECTL=/tmp/kubebuilder/bin/kubectl
           export TEST_ASSET_KUBE_APISERVER=/tmp/kubebuilder/bin/kube-apiserver
           export TEST_ASSET_ETCD=/tmp/kubebuilder/bin/etcd
           make test
+      - name: Checkout unit-test-coverage
+        uses: actions/checkout@v2
+        with:
+          repository: theketchio/unit-test-coverage
+          ref: main
+          path: unit-test-coverage
+      - name: build coverage-tester
+        run: go build -o unit-tester unit-test-coverage/main.go
+      - name: validate unit Tests
+        run: ./unit-tester --coverage coverage.txt --limits ci/limits.json
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: manager ketch
 # Run tests
 .PHONY: test
 test: generate fmt vet manifests
-	go test ./... -coverprofile cover.out
+	go test ./... -coverprofile cover.out | tee coverage.txt
 
 # Build manager binary
 .PHONY: manager

--- a/ci/limits.json
+++ b/ci/limits.json
@@ -1,0 +1,21 @@
+{
+	"github.com/theketchio/ketch/cmd/ketch": 61.4,
+	"github.com/theketchio/ketch/cmd/ketch/configuration": 0,
+	"github.com/theketchio/ketch/cmd/ketch/output": 68.3,
+	"github.com/theketchio/ketch/cmd/manager": 0,
+	"github.com/theketchio/ketch/codeprofile/unit_test_coverage": 0,
+	"github.com/theketchio/ketch/internal/api/v1beta1": 33.2,
+	"github.com/theketchio/ketch/internal/api/v1beta1/mocks": 0,
+	"github.com/theketchio/ketch/internal/build": 92.3,
+	"github.com/theketchio/ketch/internal/chart": 67.8,
+	"github.com/theketchio/ketch/internal/controllers": 55.7,
+	"github.com/theketchio/ketch/internal/deploy": 26.5,
+	"github.com/theketchio/ketch/internal/errors": 50,
+	"github.com/theketchio/ketch/internal/mocks": 0,
+	"github.com/theketchio/ketch/internal/pack": 0,
+	"github.com/theketchio/ketch/internal/templates": 5,
+	"github.com/theketchio/ketch/internal/templates/generator": 0,
+	"github.com/theketchio/ketch/internal/utils": 0,
+	"github.com/theketchio/ketch/internal/utils/conversions": 0,
+	"github.com/theketchio/ketch/internal/validation": 0
+}


### PR DESCRIPTION
# Description

Fixes # [2139](https://shipaio.atlassian.net/browse/SHIPA-2139?atlOrigin=eyJpIjoiODkxMDI0NjBlMWQ1NDhjZGFhNGM1OGFmNGVkMmEwMTgiLCJwIjoiaiJ9)

Relies on https://github.com/theketchio/unit-test-coverage, which I made public. `unit-test-coverage` may be used by our private shipa repos, but I figured it should be public as it is used by Ketch. This PR adds CI steps that run `unit-test-covreage` using `ci/limits.json`. In the event test coverage drops below the current level specified in limits.json, you'll get a failure and see output like this:

![Screen Shot 2021-11-17 at 9 41 03 AM](https://user-images.githubusercontent.com/4924621/142939741-6586504c-193a-44cb-a948-9931783fd46e.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
