### PR TITLE
Adds missing rbac verbs to kubebuilder tags

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,9 +25,9 @@ rules:
   verbs:
   - create
   - delete
+  - list
   - patch
   - update
-  - list
   - watch
 - apiGroups:
   - ""

--- a/internal/controllers/app_controller.go
+++ b/internal/controllers/app_controller.go
@@ -103,7 +103,7 @@ const (
 // +kubebuilder:rbac:groups="traefik.containo.us",resources=ingressroutes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="traefik.containo.us",resources=traefikservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="traefik.containo.us",resources=traefikservices/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update;delete;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 
 func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
# Description

`make manifests` was removing `watch` and `list` from `events` rbac perms. _This_ will do the trick.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
