### PR TITLE
Prevent pod scaling if app is the target of an HPA

### DIFF
--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -525,7 +525,7 @@ func getUpdatedUnits(weight uint8, targetUnits uint16) (int, int) {
 
 // DoCanary checks if canary deployment is needed for an app and gradually increases the traffic weight
 // based on the canary parameters provided by the users. Use it in app controller.
-func (app *App) DoCanary(now metav1.Time, logger logr.Logger, recorder record.EventRecorder) error {
+func (app *App) DoCanary(now metav1.Time, logger logr.Logger, recorder record.EventRecorder, disableScale bool) error {
 	if !app.Spec.Canary.Active {
 		failEvent := newCanaryEvent(app, CanaryNotActiveEvent, CanaryNotActiveEventDesc)
 		recorder.AnnotatedEventf(app, failEvent.Annotations, v1.EventTypeNormal, failEvent.Name, failEvent.Message())
@@ -556,7 +556,7 @@ func (app *App) DoCanary(now metav1.Time, logger logr.Logger, recorder record.Ev
 		eventStep := newCanaryNextStepEvent(app)
 		recorder.AnnotatedEventf(app, eventStep.Event.Annotations, v1.EventTypeNormal, eventStep.Event.Name, eventStep.Message())
 
-		if app.Spec.Canary.Target != nil {
+		if app.Spec.Canary.Target != nil && !disableScale {
 			// scale units based on weight and process target
 			for processName, target := range app.Spec.Canary.Target {
 				p1Units, p2Units := getUpdatedUnits(app.Spec.Deployments[0].RoutingSettings.Weight, target)

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -1086,45 +1086,6 @@ func TestApp_DoCanary(t *testing.T) {
 			},
 		},
 		{
-			// process not in target should be updated to 1 unit
-			name: "updated version's process not in target",
-			now:  *timeRef(10, 31),
-			app: App{
-				Spec: AppSpec{
-					Canary: CanarySpec{
-						Steps:             5,
-						StepWeight:        20,
-						StepTimeInteval:   10 * time.Minute,
-						NextScheduledTime: timeRef(10, 30),
-						CurrentStep:       1,
-						Active:            true,
-						Target:            map[string]uint16{"p1": 7},
-					},
-					Deployments: []AppDeploymentSpec{
-						{Version: 2, RoutingSettings: RoutingSettings{Weight: 80}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(1)}}},
-						{Version: 3, RoutingSettings: RoutingSettings{Weight: 20}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(1)}, {Name: "p2", Units: intRef(4)}}},
-					},
-				},
-			},
-			wantApp: App{
-				Spec: AppSpec{
-					Canary: CanarySpec{
-						Steps:             5,
-						StepWeight:        20,
-						StepTimeInteval:   10 * time.Minute,
-						NextScheduledTime: timeRef(10, 40),
-						CurrentStep:       2,
-						Active:            true,
-						Target:            map[string]uint16{"p1": 7},
-					},
-					Deployments: []AppDeploymentSpec{
-						{Version: 2, RoutingSettings: RoutingSettings{Weight: 60}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(4)}}},
-						{Version: 3, RoutingSettings: RoutingSettings{Weight: 40}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(3)}, {Name: "p2", Units: intRef(1)}}},
-					},
-				},
-			},
-		},
-		{
 			// process not in target should keep its units until canary completes
 			name: "previous version's process not in target",
 			now:  *timeRef(10, 31),

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -969,7 +969,7 @@ func TestApp_DoCanary(t *testing.T) {
 		name           string
 		app            App
 		now            metav1.Time
-		disableScaling bool
+		disableScaling map[string]bool
 		wantNoChanges  bool
 		wantApp        App
 		wantErr        string
@@ -1188,8 +1188,8 @@ func TestApp_DoCanary(t *testing.T) {
 			},
 		},
 		{
-			// weight should still change, but units should remain the same
-			name: "disable pod scaling",
+			// process' weight should still change, but units should remain the same if specified in disableScaling
+			name: "disable pod scaling per process",
 			now:  *timeRef(10, 31),
 			app: App{
 				Spec: AppSpec{
@@ -1200,15 +1200,15 @@ func TestApp_DoCanary(t *testing.T) {
 						NextScheduledTime: timeRef(10, 30),
 						CurrentStep:       1,
 						Active:            true,
-						Target:            map[string]uint16{"p1": 7},
+						Target:            map[string]uint16{"p1": 7, "p2": 10},
 					},
 					Deployments: []AppDeploymentSpec{
-						{Version: 2, RoutingSettings: RoutingSettings{Weight: 80}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(1)}}},
-						{Version: 3, RoutingSettings: RoutingSettings{Weight: 20}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(1)}, {Name: "p2", Units: intRef(4)}}},
+						{Version: 2, RoutingSettings: RoutingSettings{Weight: 80}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(7)}, {Name: "p2", Units: intRef(8)}}},
+						{Version: 3, RoutingSettings: RoutingSettings{Weight: 20}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(7)}, {Name: "p2", Units: intRef(2)}}},
 					},
 				},
 			},
-			disableScaling: true,
+			disableScaling: map[string]bool{"p1": true},
 			wantApp: App{
 				Spec: AppSpec{
 					Canary: CanarySpec{
@@ -1218,11 +1218,11 @@ func TestApp_DoCanary(t *testing.T) {
 						NextScheduledTime: timeRef(10, 40),
 						CurrentStep:       2,
 						Active:            true,
-						Target:            map[string]uint16{"p1": 7},
+						Target:            map[string]uint16{"p1": 7, "p2": 10},
 					},
 					Deployments: []AppDeploymentSpec{
-						{Version: 2, RoutingSettings: RoutingSettings{Weight: 60}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(1)}}},
-						{Version: 3, RoutingSettings: RoutingSettings{Weight: 40}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(1)}, {Name: "p2", Units: intRef(4)}}},
+						{Version: 2, RoutingSettings: RoutingSettings{Weight: 60}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(7)}, {Name: "p2", Units: intRef(6)}}},
+						{Version: 3, RoutingSettings: RoutingSettings{Weight: 40}, Processes: []ProcessSpec{{Name: "p1", Units: intRef(7)}, {Name: "p2", Units: intRef(4)}}},
 					},
 				},
 			},

--- a/internal/controllers/app_controller.go
+++ b/internal/controllers/app_controller.go
@@ -361,7 +361,7 @@ func (r *AppReconciler) watchDeployEvents(ctx context.Context, app *ketchv1.App,
 	}
 
 	opts := metav1.ListOptions{
-		FieldSelector: "involvedObject.kind=Deployment",
+		FieldSelector: "involvedObject.kind=Pod",
 		Watch:         true,
 	}
 	watcher, err := cli.CoreV1().Events(namespace).Watch(ctx, opts) // requires "watch" permission on events in clusterrole

--- a/internal/controllers/app_controller_test.go
+++ b/internal/controllers/app_controller_test.go
@@ -541,24 +541,41 @@ func TestIsHPATarget(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name      string
-		hpaTarget string
-		expected  map[string]bool
+		name              string
+		hpaScaleTargetRef v2beta1.CrossVersionObjectReference
+		expected          map[string]bool
 	}{
 		{
-			name:      "is target",
-			hpaTarget: "app-worker-2",
-			expected:  map[string]bool{"worker": true},
+			name: "is target",
+			hpaScaleTargetRef: v2beta1.CrossVersionObjectReference{
+				Name:       "app-worker-2",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			expected: map[string]bool{"worker": true},
 		},
 		{
-			name:      "not target",
-			hpaTarget: "target",
-			expected:  map[string]bool{},
+			name: "not target",
+			hpaScaleTargetRef: v2beta1.CrossVersionObjectReference{
+				Name:       "target",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			expected: map[string]bool{},
+		},
+		{
+			name: "mismatched apiVersion/Kind",
+			hpaScaleTargetRef: v2beta1.CrossVersionObjectReference{
+				Name:       "app-worker-2",
+				APIVersion: "fake/v3",
+				Kind:       "TestKind",
+			},
+			expected: map[string]bool{},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			hpaList.Items[0].Spec.ScaleTargetRef.Name = tc.hpaTarget
+			hpaList.Items[0].Spec.ScaleTargetRef = tc.hpaScaleTargetRef
 			require.Equal(t, tc.expected, hpaTargetMap(&app, hpaList))
 		})
 	}

--- a/internal/controllers/app_controller_test.go
+++ b/internal/controllers/app_controller_test.go
@@ -543,22 +543,23 @@ func TestIsHPATarget(t *testing.T) {
 	tests := []struct {
 		name      string
 		hpaTarget string
-		expected  bool
+		expected  map[string]bool
 	}{
 		{
 			name:      "is target",
 			hpaTarget: "app-worker-2",
-			expected:  true,
+			expected:  map[string]bool{"worker": true},
 		},
 		{
 			name:      "not target",
 			hpaTarget: "target",
+			expected:  map[string]bool{},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			hpaList.Items[0].Spec.ScaleTargetRef.Name = tc.hpaTarget
-			require.Equal(t, tc.expected, isHPATarget(&app, hpaList))
+			require.Equal(t, tc.expected, hpaTargetMap(&app, hpaList))
 		})
 	}
 }


### PR DESCRIPTION
# Description

If there is an HPA for an app, we do not want units to be scaled in canary deployment

Fixes # 2147

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
