### PR TITLE
Remove framework.{Labels, Annotations} fields

### DIFF
--- a/config/crd/bases/theketch.io_frameworks.yaml
+++ b/config/crd/bases/theketch.io_frameworks.yaml
@@ -49,10 +49,6 @@ spec:
           spec:
             description: FrameworkSpec defines the desired state of Framework
             properties:
-              annotations:
-                additionalProperties:
-                  type: string
-                type: object
               appQuotaLimit:
                 type: integer
               ingressController:
@@ -75,10 +71,6 @@ spec:
                     type: string
                 required:
                 - type
-                type: object
-              labels:
-                additionalProperties:
-                  type: string
                 type: object
               name:
                 type: string

--- a/internal/api/v1beta1/framework_types.go
+++ b/internal/api/v1beta1/framework_types.go
@@ -57,10 +57,6 @@ type FrameworkSpec struct {
 
 	AppQuotaLimit *int `json:"appQuotaLimit"`
 
-	Annotations map[string]string `json:"annotations,omitempty"`
-
-	Labels map[string]string `json:"labels,omitempty"`
-
 	IngressController IngressControllerSpec `json:"ingressController,omitempty"`
 }
 

--- a/internal/controllers/framework_controller.go
+++ b/internal/controllers/framework_controller.go
@@ -113,12 +113,6 @@ func (r *FrameworkReconciler) reconcile(ctx context.Context, framework *ketchv1.
 		}
 	}
 
-	namespace.Annotations = framework.Spec.Annotations
-	if namespace.Annotations == nil {
-		namespace.Annotations = map[string]string{}
-	}
-
-	namespace.Labels = framework.Spec.Labels
 	if namespace.Labels == nil {
 		namespace.Labels = map[string]string{}
 	}


### PR DESCRIPTION
The fields are not used and they are implemented in a way that ketch always override a namespace's annotations/labels