### PR TITLE
Keep only 1 historical helm release per app on cluster

### DIFF
--- a/ci/limits.json
+++ b/ci/limits.json
@@ -7,7 +7,7 @@
 	"github.com/theketchio/ketch/internal/api/v1beta1": 33.2,
 	"github.com/theketchio/ketch/internal/api/v1beta1/mocks": 0,
 	"github.com/theketchio/ketch/internal/build": 92.3,
-	"github.com/theketchio/ketch/internal/chart": 67.8,
+	"github.com/theketchio/ketch/internal/chart": 67.7,
 	"github.com/theketchio/ketch/internal/controllers": 55.7,
 	"github.com/theketchio/ketch/internal/deploy": 26.5,
 	"github.com/theketchio/ketch/internal/errors": 50,

--- a/internal/chart/helm_client.go
+++ b/internal/chart/helm_client.go
@@ -94,9 +94,10 @@ func (c HelmClient) UpdateChart(tv TemplateValuer, config ChartConfig, opts ...I
 	}
 	updateClient := action.NewUpgrade(c.cfg)
 	updateClient.Namespace = c.namespace
-	// MaxHistory=0 means there is an unlimited number of k8s secrets per application,
-	// and the number keeps growing.
-	// Let's set it to minimal.
+
+	// MaxHistory specifies the maximum number of historical releases that will be retained, including the most recent release.
+	// Values of 0 or less are ignored (meaning no limits are imposed).
+	// Let's set it to minimal to disable "helm rollback".
 	updateClient.MaxHistory = 1
 	updateClient.PostRenderer = &postRender{
 		namespace: c.namespace,


### PR DESCRIPTION
   Currently, we don't specify MaxHistory and a number of helm releases
keeps growing meaning ketch creates lots of secrets named
`sh.helm.release.v1.<app-name>.v<version>`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

