### PR TITLE
Make sure all resources contain theketch.io/app-name label

### DIFF
--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -342,6 +342,8 @@ kind: Certificate
 metadata:
   name: "dashboard-cname-theketch-io"
   namespace: istio-system
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   secretName: dashboard-cname-theketch-io
   dnsNames:
@@ -356,6 +358,8 @@ kind: Certificate
 metadata:
   name: "dashboard-cname-app-theketch-io"
   namespace: istio-system
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   secretName: dashboard-cname-app-theketch-io
   dnsNames:
@@ -369,6 +373,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: shipa-dashboard-rule-3
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   host: dashboard-web-3
   subsets:
@@ -382,6 +388,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: shipa-dashboard-rule-4
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   host: dashboard-web-4
   subsets:

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -341,6 +341,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: shipa-dashboard-rule-3
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   host: dashboard-web-3
   subsets:
@@ -354,6 +356,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: shipa-dashboard-rule-4
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   host: dashboard-web-4
   subsets:

--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -501,6 +501,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "dashboard-cname-theketch-io"
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-theketch-io"
   dnsNames:
@@ -514,6 +516,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "dashboard-cname-app-theketch-io"
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
   dnsNames:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -341,6 +341,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "dashboard-cname-theketch-io"
+  labels:
+    shipa.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-theketch-io"
   dnsNames:
@@ -354,6 +356,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "dashboard-cname-app-theketch-io"
+  labels:
+    shipa.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
   dnsNames:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -341,6 +341,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "dashboard-cname-theketch-io"
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-theketch-io"
   dnsNames:
@@ -354,6 +356,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "dashboard-cname-app-theketch-io"
+  labels:
+    theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
   dnsNames:

--- a/internal/templates/istio/yamls/certificate.yaml
+++ b/internal/templates/istio/yamls/certificate.yaml
@@ -5,6 +5,8 @@ kind: Certificate
 metadata:
   name: {{ $https.secretName | quote }}
   namespace: istio-system
+  labels:
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   secretName: {{ $https.secretName }}
   dnsNames:

--- a/internal/templates/istio/yamls/destinationRule.yaml
+++ b/internal/templates/istio/yamls/destinationRule.yaml
@@ -5,6 +5,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: shipa-{{ $.Values.app.name}}-rule-{{ $deployment.version }}
+  labels:
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   host: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
   subsets:

--- a/internal/templates/nginx/yamls/certificate.yaml
+++ b/internal/templates/nginx/yamls/certificate.yaml
@@ -4,6 +4,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $https.secretName | quote }}
+  labels:
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   secretName: {{ $https.secretName | quote }}
   dnsNames:

--- a/internal/templates/traefik/yamls/certificate.yaml
+++ b/internal/templates/traefik/yamls/certificate.yaml
@@ -4,6 +4,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $https.secretName | quote }}
+  labels:
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   secretName: {{ $https.secretName | quote }}
   dnsNames:


### PR DESCRIPTION
Some of k8s resources of the app helm chart didn't have theketch.io/app-name label making it hard to query a cluster to get all app resources 

- [x] Bug fix (non-breaking change which fixes an issue)
