### PR TITLE
Add theketch.io/app-name label to secrets provisioning by cert-manager

### DIFF
--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -346,6 +346,9 @@ metadata:
     theketch.io/app-name: "dashboard"
 spec:
   secretName: dashboard-cname-theketch-io
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
   dnsNames:
     - theketch.io
   issuerRef:
@@ -362,6 +365,9 @@ metadata:
     theketch.io/app-name: "dashboard"
 spec:
   secretName: dashboard-cname-app-theketch-io
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
   dnsNames:
     - app.theketch.io
   issuerRef:

--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -505,6 +505,9 @@ metadata:
     theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-theketch-io"
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
   dnsNames:
     - theketch.io
   issuerRef:
@@ -520,6 +523,9 @@ metadata:
     theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
   dnsNames:
     - app.theketch.io
   issuerRef:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -345,6 +345,9 @@ metadata:
     shipa.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-theketch-io"
+  secretTemplate:
+    labels:
+      shipa.io/app-name: "dashboard"
   dnsNames:
     - theketch.io
   issuerRef:
@@ -360,6 +363,9 @@ metadata:
     shipa.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
+  secretTemplate:
+    labels:
+      shipa.io/app-name: "dashboard"
   dnsNames:
     - app.theketch.io
   issuerRef:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -345,6 +345,9 @@ metadata:
     theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-theketch-io"
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
   dnsNames:
     - theketch.io
   issuerRef:
@@ -360,6 +363,9 @@ metadata:
     theketch.io/app-name: "dashboard"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
   dnsNames:
     - app.theketch.io
   issuerRef:

--- a/internal/templates/istio/yamls/certificate.yaml
+++ b/internal/templates/istio/yamls/certificate.yaml
@@ -9,6 +9,9 @@ metadata:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   secretName: {{ $https.secretName }}
+  secretTemplate:
+    labels:
+      {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
   dnsNames:
     - {{ $https.cname }}
   issuerRef:

--- a/internal/templates/nginx/yamls/certificate.yaml
+++ b/internal/templates/nginx/yamls/certificate.yaml
@@ -8,6 +8,9 @@ metadata:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   secretName: {{ $https.secretName | quote }}
+  secretTemplate:
+    labels:
+      {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
   dnsNames:
     - {{ $https.cname }}
   issuerRef:

--- a/internal/templates/traefik/yamls/certificate.yaml
+++ b/internal/templates/traefik/yamls/certificate.yaml
@@ -8,6 +8,9 @@ metadata:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
   secretName: {{ $https.secretName | quote }}
+  secretTemplate:
+    labels:
+      {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
   dnsNames:
     - {{ $https.cname }}
   issuerRef:


### PR DESCRIPTION
Currently, all app resources except secrets created by cert-manager have `theketch.io/app-name` label. 
This PR forces cert-manager to create secrets with this label. 

  https://cert-manager.io/docs/usage/certificate/#creating-certificate-resources


- [x] Bug fix (non-breaking change which fixes an issue)
