### PR TITLE
Fix helm update client forever blocked

### DIFF
--- a/ci/limits.json
+++ b/ci/limits.json
@@ -7,7 +7,7 @@
 	"github.com/theketchio/ketch/internal/api/v1beta1": 33.2,
 	"github.com/theketchio/ketch/internal/api/v1beta1/mocks": 0,
 	"github.com/theketchio/ketch/internal/build": 92.3,
-	"github.com/theketchio/ketch/internal/chart": 67.7,
+	"github.com/theketchio/ketch/internal/chart": 65.7,
 	"github.com/theketchio/ketch/internal/controllers": 55.7,
 	"github.com/theketchio/ketch/internal/deploy": 26.5,
 	"github.com/theketchio/ketch/internal/errors": 50,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -124,7 +124,7 @@ func main() {
 		Log:            logg,
 		Scheme:         mgr.GetScheme(),
 		HelmFactoryFn: func(namespace string) (controllers.Helm, error) {
-			return chart.NewHelmClient(namespace, mgr.GetClient())
+			return chart.NewHelmClient(namespace, mgr.GetClient(), logg)
 		},
 		Now:   time.Now,
 		Group: group,
@@ -144,7 +144,7 @@ func main() {
 		Scheme:         mgr.GetScheme(),
 		TemplateReader: storage,
 		HelmFactoryFn: func(namespace string) (controllers.Helm, error) {
-			return chart.NewHelmClient(namespace, mgr.GetClient())
+			return chart.NewHelmClient(namespace, mgr.GetClient(), logg)
 		},
 		Recorder: eventBroadcaster.NewRecorder(clientgoscheme.Scheme, v1.EventSource{
 			Component: "ketch-controller",

--- a/internal/chart/helm_client.go
+++ b/internal/chart/helm_client.go
@@ -45,7 +45,7 @@ func NewHelmClient(namespace string, c client.Client, log logr.Logger) (*HelmCli
 	if err != nil {
 		return nil, err
 	}
-	return &HelmClient{cfg: cfg, namespace: namespace, c: c, log: log.WithValues("helm_client")}, nil
+	return &HelmClient{cfg: cfg, namespace: namespace, c: c, log: log.WithValues("helm-client", namespace)}, nil
 }
 
 func getActionConfig(namespace string) (*action.Configuration, error) {

--- a/internal/chart/helm_client.go
+++ b/internal/chart/helm_client.go
@@ -118,7 +118,7 @@ func (c HelmClient) UpdateChart(tv TemplateValuer, config ChartConfig, opts ...I
 			c.log.Info(fmt.Sprintf("Found pending helm release: %d", lastRelease.Version))
 			timeoutLimit := time.Now().Add(-defaultDeploymentTimeout)
 			if lastRelease.Info.FirstDeployed.Before(helmTime.Time{Time: timeoutLimit}) {
-				newStatus := release.StatusFailed
+				newStatus := release.StatusDeployed
 				c.log.Info(fmt.Sprintf("Setting status of release that has timeouted to: %s", newStatus))
 				lastRelease.SetStatus(newStatus, "manually canceled")
 				if err := c.cfg.Releases.Update(lastRelease); err != nil {

--- a/internal/chart/helm_client.go
+++ b/internal/chart/helm_client.go
@@ -2,16 +2,25 @@ package chart
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
+	"time"
 
+	"github.com/go-logr/logr"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	helmTime "helm.sh/helm/v3/pkg/time"
+
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultDeploymentTimeout = 10 * time.Minute
 )
 
 // HelmClient performs helm install and uninstall operations for provided application helm charts.
@@ -19,6 +28,7 @@ type HelmClient struct {
 	cfg       *action.Configuration
 	namespace string
 	c         client.Client
+	log       logr.Logger
 }
 
 // TemplateValuer is an interface that permits types that implement it (e.g. Application, Job)
@@ -30,12 +40,12 @@ type TemplateValuer interface {
 }
 
 // NewHelmClient returns a HelmClient instance.
-func NewHelmClient(namespace string, c client.Client) (*HelmClient, error) {
+func NewHelmClient(namespace string, c client.Client, log logr.Logger) (*HelmClient, error) {
 	cfg, err := getActionConfig(namespace)
 	if err != nil {
 		return nil, err
 	}
-	return &HelmClient{cfg: cfg, namespace: namespace, c: c}, nil
+	return &HelmClient{cfg: cfg, namespace: namespace, c: c, log: log.WithValues("helm_client")}, nil
 }
 
 func getActionConfig(namespace string) (*action.Configuration, error) {
@@ -95,6 +105,28 @@ func (c HelmClient) UpdateChart(tv TemplateValuer, config ChartConfig, opts ...I
 	updateClient := action.NewUpgrade(c.cfg)
 	updateClient.Namespace = c.namespace
 
+	// we check releases and if lastRelease release was a while back, we set its status to Failure
+	// next helm update won't be blocked in that case
+	// this is an edge case we should cover when ketch controller pod gets restarted in middle of deploying and app
+	// in that case if helm secret (release) remains it would block next deployment forever
+	lastRelease, err := c.cfg.Releases.Last(appName)
+	if err != nil && err != driver.ErrReleaseNotFound {
+		return nil, err
+	}
+	if lastRelease != nil {
+		if lastRelease.Info.Status.IsPending() {
+			c.log.Info(fmt.Sprintf("Found pending helm release: %d", lastRelease.Version))
+			timeoutLimit := time.Now().Add(-defaultDeploymentTimeout)
+			if lastRelease.Info.FirstDeployed.Before(helmTime.Time{Time: timeoutLimit}) {
+				newStatus := release.StatusFailed
+				c.log.Info(fmt.Sprintf("Setting status of release that has timeouted to: %s", newStatus))
+				lastRelease.SetStatus(newStatus, "manually canceled")
+				if err := c.cfg.Releases.Update(lastRelease); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
 	// MaxHistory specifies the maximum number of historical releases that will be retained, including the most recent release.
 	// Values of 0 or less are ignored (meaning no limits are imposed).
 	// Let's set it to minimal to disable "helm rollback".


### PR DESCRIPTION
# Description

- set helm release secret status to Failed before doing helm update if release was created more than 10 minutes ago
- this should unblock next helm update of application

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
