### PR TITLE
Set ketch-controller as finalizer for App CR

### DIFF
--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -35,6 +35,7 @@ import (
 const (
 	ShipaCloudDomain     = "shipa.cloud"
 	DefaultNumberOfUnits = 1
+	KetchFinalizer       = "ketch-controller"
 )
 
 // Env represents an environment variable present in an application.


### PR DESCRIPTION
   Previously, if ketch controller was being restarted and somebody
deleted an app CR, the corresponding helm chart was not deleted because
ketch didn't get DELETE event.

- [x] Bug fix (non-breaking change which fixes an issue)

