### PR TITLE
Ketch controller to request 100m cpu and 300Mi memory

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,8 +35,8 @@ spec:
         name: manager
         resources:
           requests:
-            cpu: 700m
-            memory: 1024Mi
+            cpu: 100m
+            memory: 300Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Ketch controller consumes 100m memory on average and uses 10-15m cpu. 
(measured with metrics-server) 
