### PR TITLE
[SHIPA-2322] adds wait-retry to helm update & delete

### DIFF
--- a/internal/chart/helm_client.go
+++ b/internal/chart/helm_client.go
@@ -15,46 +15,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type statusFunc func(cfg *action.Configuration, appName string) (*release.Release, release.Status, error)
+type statusFunc func(cfg *action.Configuration, appName string) (release.Status, error)
 
 const (
-	WaitRetry = iota
-	TakeAction
-	NoAction
+	waitRetry = iota
+	takeAction
+	noAction
+
+	notFound release.Status = "not-found"
 )
 
 // helmStatusActionMapUpdate maps a Release Status to a Ketch action for helm updates
 var helmStatusActionMapUpdate = map[release.Status]int{
-	"not-found":                   TakeAction,
-	release.StatusUnknown:         WaitRetry,
-	release.StatusDeployed:        TakeAction,
-	release.StatusUninstalled:     TakeAction,
-	release.StatusSuperseded:      NoAction,
-	release.StatusFailed:          TakeAction,
-	release.StatusUninstalling:    WaitRetry,
-	release.StatusPendingInstall:  WaitRetry,
-	release.StatusPendingUpgrade:  WaitRetry,
-	release.StatusPendingRollback: WaitRetry,
+	notFound:                      takeAction,
+	release.StatusUnknown:         waitRetry,
+	release.StatusDeployed:        takeAction,
+	release.StatusUninstalled:     takeAction,
+	release.StatusSuperseded:      noAction,
+	release.StatusFailed:          takeAction,
+	release.StatusUninstalling:    waitRetry,
+	release.StatusPendingInstall:  waitRetry,
+	release.StatusPendingUpgrade:  waitRetry,
+	release.StatusPendingRollback: waitRetry,
 }
 
 // helmStatusActionMapDelete maps a Release Status to a Ketch action for helm deletions
 var helmStatusActionMapDelete = map[release.Status]int{
-	"not-found":                   NoAction,
-	release.StatusUnknown:         WaitRetry,
-	release.StatusDeployed:        TakeAction,
-	release.StatusUninstalled:     NoAction,
-	release.StatusSuperseded:      NoAction,
-	release.StatusFailed:          NoAction,
-	release.StatusUninstalling:    NoAction,
-	release.StatusPendingInstall:  WaitRetry,
-	release.StatusPendingUpgrade:  WaitRetry,
-	release.StatusPendingRollback: WaitRetry,
+	notFound:                      noAction,
+	release.StatusUnknown:         waitRetry,
+	release.StatusDeployed:        takeAction,
+	release.StatusUninstalled:     noAction,
+	release.StatusSuperseded:      noAction,
+	release.StatusFailed:          noAction,
+	release.StatusUninstalling:    noAction,
+	release.StatusPendingInstall:  waitRetry,
+	release.StatusPendingUpgrade:  waitRetry,
+	release.StatusPendingRollback: waitRetry,
 }
-
-var (
-	statusRetryInterval = time.Second * 1
-	statusRetryTimeout  = time.Second * 5
-)
 
 const (
 	defaultDeploymentTimeout = 10 * time.Minute
@@ -147,7 +144,7 @@ func (c HelmClient) UpdateChart(tv TemplateValuer, config ChartConfig, opts ...I
 		namespace: c.namespace,
 		cli:       c.c,
 	}
-	shouldUpdate, err := c.waitForActionableStatus(c.statusFunc, appName, helmStatusActionMapUpdate)
+	shouldUpdate, err := c.isHelmChartStatusActionable(c.statusFunc, appName, helmStatusActionMapUpdate)
 	if err != nil || !shouldUpdate {
 		return nil, err
 	}
@@ -156,7 +153,7 @@ func (c HelmClient) UpdateChart(tv TemplateValuer, config ChartConfig, opts ...I
 
 // DeleteChart uninstalls the app's helm release. It doesn't return an error if the release is not found.
 func (c HelmClient) DeleteChart(appName string) error {
-	shouldDelete, err := c.waitForActionableStatus(c.statusFunc, appName, helmStatusActionMapDelete)
+	shouldDelete, err := c.isHelmChartStatusActionable(c.statusFunc, appName, helmStatusActionMapDelete)
 	if err != nil || !shouldDelete {
 		return err
 	}
@@ -168,46 +165,34 @@ func (c HelmClient) DeleteChart(appName string) error {
 	return err
 }
 
-// getHelmStatus returns the Release, Status, and error for an app
-func getHelmStatus(cfg *action.Configuration, appName string) (*release.Release, release.Status, error) {
+// getHelmStatus returns the Status, and error for an app
+func getHelmStatus(cfg *action.Configuration, appName string) (release.Status, error) {
 	statusClient := action.NewStatus(cfg)
 	status, err := statusClient.Run(appName)
 	if err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) || status.Info == nil {
-			return nil, "not-found", nil
+			return notFound, nil
 		}
-		return nil, "", err
+		return "", err
 	}
-	return status, status.Info.Status, nil
+	return status.Info.Status, nil
 }
 
-// waitForActionableStatus returns true if the helm status is such that it is ok to proceed with update/delete. If the statusFunc returns
-// WaitRetry, the func blocks while retrying.
-func (c HelmClient) waitForActionableStatus(statusFunc statusFunc, appName string, statusActionMap map[release.Status]int) (bool, error) {
-	ticker := time.NewTicker(statusRetryInterval)
-	done := time.After(statusRetryTimeout)
-	var helmRelease *release.Release
-	var status release.Status
-	var err error
-	for {
-		select {
-		case <-done:
-			c.log.Info(fmt.Sprintf("Setting status (%s) of %s release that has timeouted to: deployed", appName, status))
-			helmRelease.SetStatus(release.StatusDeployed, "set manually after timeout waiting for actionable status")
-			return true, nil
-		case <-ticker.C:
-			helmRelease, status, err = statusFunc(c.cfg, appName)
-			if err != nil {
-				return false, err
-			}
-			action := statusActionMap[status] // default wait-retry
-			if action == NoAction {
-				c.log.Info(fmt.Sprintf("helm chart for app %s release already in state %s - no action required", appName, status))
-				return false, nil
-			}
-			if action == TakeAction {
-				return true, nil
-			}
-		}
+// isHelmChartStatusActionable returns true if the statusFunc returns an actionable status according to the statusActionMap, false if the status is
+// non-actionable (e.g. "not-found" status for a "delete" action), and an error if the status requires a wait-retry. The retry is expected to be
+// executed by the calling reconciler's inherent looping.
+func (c HelmClient) isHelmChartStatusActionable(statusFunc statusFunc, appName string, statusActionMap map[release.Status]int) (bool, error) {
+	status, err := statusFunc(c.cfg, appName)
+	if err != nil {
+		return false, err
+	}
+	switch statusActionMap[status] {
+	case noAction:
+		c.log.Info(fmt.Sprintf("helm chart for app %s release already in state %s - no action required", appName, status))
+		return false, nil
+	case takeAction:
+		return true, nil
+	default:
+		return false, fmt.Errorf("helm chart for app %s in non-actionable status %s", appName, status)
 	}
 }

--- a/internal/chart/helm_client_factory.go
+++ b/internal/chart/helm_client_factory.go
@@ -51,7 +51,7 @@ func (f *HelmClientFactory) NewHelmClient(namespace string, c client.Client, log
 		f.configurations[namespace] = cfg
 	}
 	f.configurationsLastUsedTimes[namespace] = time.Now()
-	return &HelmClient{cfg: cfg, namespace: namespace, c: c, log: log.WithValues("helm-client", namespace)}, nil
+	return &HelmClient{cfg: cfg, namespace: namespace, c: c, log: log.WithValues("helm-client", namespace), statusFunc: getHelmStatus}, nil
 }
 
 func (f *HelmClientFactory) cleanup() {

--- a/internal/chart/helm_client_test.go
+++ b/internal/chart/helm_client_test.go
@@ -1,0 +1,117 @@
+package chart
+
+import (
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func TestWaitForActionableStatus(t *testing.T) {
+	tests := []struct {
+		description             string
+		statusFuncMap           map[int]release.Status // sequence of responses returned by mockStatusFunc
+		statusMap               map[release.Status]int // test update or delete
+		expected                bool
+		expectedStatusFuncCalls int
+	}{
+		{
+			description:             "delete - deployed",
+			statusFuncMap:           map[int]release.Status{0: release.StatusDeployed},
+			statusMap:               helmStatusActionMapDelete,
+			expected:                true,
+			expectedStatusFuncCalls: 1,
+		},
+		{
+			description:             "delete - eventual success",
+			statusFuncMap:           map[int]release.Status{0: release.StatusUnknown, 1: release.StatusDeployed},
+			statusMap:               helmStatusActionMapDelete,
+			expected:                true,
+			expectedStatusFuncCalls: 2,
+		},
+		{
+			description:             "delete - not found",
+			statusFuncMap:           map[int]release.Status{0: "not-found"},
+			statusMap:               helmStatusActionMapDelete,
+			expected:                false,
+			expectedStatusFuncCalls: 1,
+		},
+		{
+			description:             "delete - superseded",
+			statusFuncMap:           map[int]release.Status{0: release.StatusSuperseded},
+			statusMap:               helmStatusActionMapDelete,
+			expected:                false,
+			expectedStatusFuncCalls: 1,
+		},
+		{
+			description:             "delete timeout",
+			statusFuncMap:           map[int]release.Status{0: release.StatusPendingInstall, 1: release.StatusPendingInstall, 2: release.StatusPendingInstall, 3: release.StatusPendingInstall, 4: release.StatusPendingInstall},
+			statusMap:               helmStatusActionMapDelete,
+			expected:                true,
+			expectedStatusFuncCalls: 5,
+		},
+		{
+			description:             "update - deployed",
+			statusFuncMap:           map[int]release.Status{0: release.StatusDeployed},
+			statusMap:               helmStatusActionMapUpdate,
+			expected:                true,
+			expectedStatusFuncCalls: 1,
+		},
+		{
+			description:             "update - eventual success",
+			statusFuncMap:           map[int]release.Status{0: release.StatusUnknown, 1: release.StatusDeployed},
+			statusMap:               helmStatusActionMapUpdate,
+			expected:                true,
+			expectedStatusFuncCalls: 2,
+		},
+		{
+			description:             "update - not found",
+			statusFuncMap:           map[int]release.Status{0: "not-found"},
+			statusMap:               helmStatusActionMapUpdate,
+			expected:                true,
+			expectedStatusFuncCalls: 1,
+		},
+		{
+			description:             "update - superseded",
+			statusFuncMap:           map[int]release.Status{0: release.StatusSuperseded},
+			statusMap:               helmStatusActionMapUpdate,
+			expected:                false,
+			expectedStatusFuncCalls: 1,
+		},
+		{
+			description:             "update timeout",
+			statusFuncMap:           map[int]release.Status{0: release.StatusPendingInstall, 1: release.StatusPendingInstall, 2: release.StatusPendingInstall, 3: release.StatusPendingInstall, 4: release.StatusPendingInstall},
+			statusMap:               helmStatusActionMapUpdate,
+			expected:                true,
+			expectedStatusFuncCalls: 5,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			c := &HelmClient{
+				log: log.NullLogger{},
+			}
+			// speed up retry, timeout
+			statusRetryInterval = time.Millisecond * 100
+			statusRetryTimeout = time.Millisecond * 500
+			// mockStatusFunc and counter to track times called
+			counter := 0
+			mockStatusFunc := func(cfg *action.Configuration, appName string) (*release.Release, release.Status, error) {
+				status := tc.statusFuncMap[counter]
+				counter += 1
+				mockRelease := &release.Release{Chart: &chart.Chart{}, Info: &release.Info{}}
+				return mockRelease, status, nil
+			}
+
+			ok, err := c.waitForActionableStatus(mockStatusFunc, "testapp", tc.statusMap)
+			require.Nil(t, err)
+			require.Equal(t, tc.expected, ok)
+			require.Equal(t, tc.expectedStatusFuncCalls, counter)
+		})
+	}
+}

--- a/internal/chart/helm_client_test.go
+++ b/internal/chart/helm_client_test.go
@@ -2,10 +2,12 @@ package chart
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/release"
+	helmTime "helm.sh/helm/v3/pkg/time"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -73,9 +75,10 @@ func TestIsHelmChartStatusActionable(t *testing.T) {
 			c := &HelmClient{
 				log: log.NullLogger{},
 			}
-			mockStatusFunc := func(cfg *action.Configuration, appName string) (release.Status, error) {
+			mockStatusFunc := func(cfg *action.Configuration, appName string) (*release.Release, release.Status, error) {
 				status := tc.status
-				return status, nil
+				currentRelease := &release.Release{Info: &release.Info{FirstDeployed: helmTime.Time{Time: time.Now()}}}
+				return currentRelease, status, nil
 			}
 
 			ok, err := c.isHelmChartStatusActionable(mockStatusFunc, "testapp", tc.statusMap)


### PR DESCRIPTION
# Description

[2322](https://shipaio.atlassian.net/browse/SHIPA-2322?atlOrigin=eyJpIjoiMmRlYTJlNjM5M2M3NGMyMjkxMTg3MjNjMTc2YmFlOTgiLCJwIjoiaiJ9) 
Helm update and helm delete currently fail when the object status (app) is not `deployed`. This change checks a map for actionable & retryable statuses for updates and deletions. For wait-retry statuses, a wait-retry loop is entered, and ultimately the status is manually updated to `deployed`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

