### PR TITLE
Shipa 2578

### DIFF
--- a/ci/limits.json
+++ b/ci/limits.json
@@ -4,7 +4,7 @@
 	"github.com/theketchio/ketch/cmd/ketch/output": 68.3,
 	"github.com/theketchio/ketch/cmd/manager": 0,
 	"github.com/theketchio/ketch/codeprofile/unit_test_coverage": 0,
-	"github.com/theketchio/ketch/internal/api/v1beta1": 33.2,
+	"github.com/theketchio/ketch/internal/api/v1beta1": 32.9,
 	"github.com/theketchio/ketch/internal/api/v1beta1/mocks": 0,
 	"github.com/theketchio/ketch/internal/build": 92.3,
 	"github.com/theketchio/ketch/internal/chart": 67.0,

--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -2537,8 +2537,32 @@ spec:
                 description: ServiceAccountName specifies a service account name to
                   be used for this application.
                 type: string
+              type:
+                description: Type specifies whether an app should be a deployment
+                  or a statefulset
+                type: string
               version:
                 type: string
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates is a list of an app's volumeClaimTemplates
+                items:
+                  properties:
+                    accessModes:
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    storage:
+                      type: string
+                    storageClassName:
+                      type: string
+                  required:
+                  - accessModes
+                  - name
+                  - storage
+                  type: object
+                type: array
             required:
             - deployments
             - framework

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,18 +7,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - statefulset
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
@@ -93,6 +81,18 @@ rules:
   - apps
   resources:
   - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
+  - apps
   resources:
   - statefulset
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - statefulset
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - create

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -236,6 +236,19 @@ type AppSpec struct {
 
 	// SecurityContext specifies security settings for a pod/app, which get applied to all containers.
 	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+
+	// VolumeClaimTemplates is a list of an app's volumeClaimTemplates
+	VolumeClaimTemplates []PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
+
+	// Type specifies whether an app should be a deployment of a statefulset
+	Type *string `json:"type,omitempty"`
+}
+
+type PersistentVolumeClaim struct {
+	Name             string                          `json:"name"`
+	AccessModes      []v1.PersistentVolumeAccessMode `json:"accessModes"`
+	StorageClassName *string                         `json:"storageClassName,omitempty"`
+	Storage          string                          `json:"storage"`
 }
 
 // MetadataItem represent a request to add label/annotations to processes

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -240,7 +240,7 @@ type AppSpec struct {
 	// VolumeClaimTemplates is a list of an app's volumeClaimTemplates
 	VolumeClaimTemplates []PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
-	// Type specifies whether an app should be a deployment of a statefulset
+	// Type specifies whether an app should be a deployment or a statefulset
 	Type *string `json:"type,omitempty"`
 }
 

--- a/internal/chart/application_chart_test.go
+++ b/internal/chart/application_chart_test.go
@@ -236,6 +236,31 @@ func TestNewApplicationChart(t *testing.T) {
 		}
 		return &out
 	}
+	setVolumeClaimTemplates := func(app *ketchv1.App) *ketchv1.App {
+		out := *app
+		storageClass := "standard"
+		out.Spec.VolumeClaimTemplates = []ketchv1.PersistentVolumeClaim{
+			{
+				Name:             "v1-shipa",
+				AccessModes:      []v1.PersistentVolumeAccessMode{"ReadWriteMany"},
+				StorageClassName: &storageClass,
+				Storage:          "1Gi",
+			},
+			{
+				Name:             "v2-shipa",
+				AccessModes:      []v1.PersistentVolumeAccessMode{"ReadWriteOnce"},
+				StorageClassName: &storageClass,
+				Storage:          "1Gi",
+			},
+		}
+		return &out
+	}
+	setStatefulSet := func(app *ketchv1.App) *ketchv1.App {
+		out := *app
+		appType := "StatefulSet"
+		out.Spec.Type = &appType
+		return &out
+	}
 
 	tests := []struct {
 		name        string
@@ -286,6 +311,16 @@ func TestNewApplicationChart(t *testing.T) {
 			application:       setPodSecurityContext(dashboard),
 			framework:         frameworkWithClusterIssuer,
 			wantYamlsFilename: "dashboard-istio-cluster-issuer-pod-security-context",
+		},
+		{
+			name: "istio templates with cluster issuer and volume claim templates",
+			opts: []Option{
+				WithTemplates(templates.IstioDefaultTemplates),
+				WithExposedPorts(exportedPorts),
+			},
+			application:       setStatefulSet(setVolumeClaimTemplates(dashboard)),
+			framework:         frameworkWithClusterIssuer,
+			wantYamlsFilename: "dashboard-istio-cluster-issuer-volume-claim-templates",
 		},
 		{
 			name: "istio templates without cluster issuer",

--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer-volume-claim-templates.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer-volume-claim-templates.yaml
@@ -1,0 +1,654 @@
+---
+# Source: dashboard/templates/gateway_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/is-isolated-run: "false"
+  name: app-dashboard
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-default-1
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+---
+# Source: dashboard/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-deployment-version: "3"
+    theketch.io/is-isolated-run: "false"
+  name: dashboard-web-3
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-default-1
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-deployment-version: "3"
+    theketch.io/is-isolated-run: "false"
+---
+# Source: dashboard/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "worker"
+    theketch.io/app-deployment-version: "3"
+    theketch.io/is-isolated-run: "false"
+  name: dashboard-worker-3
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-default-1
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "worker"
+    theketch.io/app-deployment-version: "3"
+    theketch.io/is-isolated-run: "false"
+---
+# Source: dashboard/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+  annotations:
+    theketch.io/test-annotation: "test-annotation-value"
+  name: dashboard-web-4
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-default-1
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+---
+# Source: dashboard/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "worker"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+  name: dashboard-worker-4
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-default-1
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "worker"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+---
+# Source: dashboard/templates/stateful_set.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-process-replicas: "3"
+    theketch.io/app-deployment-version: "3"
+    theketch.io/is-isolated-run: "false"
+    theketch.io/test-label: "test-label-value"
+    theketch.io/test-label-all: "test-label-value-all"
+  name: dashboard-web-3
+spec:
+  selector:
+    matchLabels:
+      app: "dashboard"
+      version: "3"
+      theketch.io/app-name: "dashboard"
+      theketch.io/app-process: "web"
+      theketch.io/app-deployment-version: "3"
+      theketch.io/is-isolated-run: "false"
+  serviceName: "dashboard"
+  template:
+    metadata:
+      labels:
+        app: "dashboard"
+        version: "3"
+        theketch.io/app-name: "dashboard"
+        theketch.io/app-process: "web"
+        theketch.io/app-deployment-version: "3"
+        theketch.io/is-isolated-run: "false"
+        pod.io/label: "pod-label"
+      annotations:
+        pod.io/annotation: "pod-annotation"
+    spec:
+      containers:
+        - name: dashboard-web-3
+          command: ["python"]
+          env:
+            - name: TEST_API_KEY
+              value: SECRET
+            - name: TEST_API_URL
+              value: example.com
+            - name: port
+              value: "9090"
+            - name: PORT
+              value: "9090"
+            - name: PORT_web
+              value: "9090"
+            - name: VAR
+              value: VALUE
+          image: shipasoftware/go-app:v1
+          ports:
+          - containerPort: 9090
+          volumeMounts:
+            - mountPath: /test-ebs
+              name: test-volume
+          resources:
+            limits:
+              cpu: 5Gi
+              memory: 5300m
+            requests:
+              cpu: 5Gi
+              memory: 5300m
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9090
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 60
+      imagePullSecrets:
+            - name: registry-secret
+            - name: private-registry-secret
+      volumes:
+            - awsElasticBlockStore:
+                fsType: ext4
+                volumeID: volume-id
+              name: test-volume
+  volumeClaimTemplates:
+  - metadata:
+      name: v1-shipa
+    spec:
+      accessModes: [ReadWriteMany]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: v2-shipa
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+---
+# Source: dashboard/templates/stateful_set.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "worker"
+    theketch.io/app-process-replicas: "1"
+    theketch.io/app-deployment-version: "3"
+    theketch.io/is-isolated-run: "false"
+    theketch.io/test-label-all: "test-label-value-all"
+  name: dashboard-worker-3
+spec:
+  selector:
+    matchLabels:
+      app: "dashboard"
+      version: "3"
+      theketch.io/app-name: "dashboard"
+      theketch.io/app-process: "worker"
+      theketch.io/app-deployment-version: "3"
+      theketch.io/is-isolated-run: "false"
+  serviceName: "dashboard"
+  template:
+    metadata:
+      labels:
+        app: "dashboard"
+        version: "3"
+        theketch.io/app-name: "dashboard"
+        theketch.io/app-process: "worker"
+        theketch.io/app-deployment-version: "3"
+        theketch.io/is-isolated-run: "false"
+    spec:
+      containers:
+        - name: dashboard-worker-3
+          command: ["celery"]
+          env:
+            - name: port
+              value: "9090"
+            - name: PORT
+              value: "9090"
+            - name: PORT_worker
+              value: "9090"
+            - name: VAR
+              value: VALUE
+          image: shipasoftware/go-app:v1
+          ports:
+          - containerPort: 9090
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9090
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 60
+      imagePullSecrets:
+            - name: registry-secret
+            - name: private-registry-secret
+  volumeClaimTemplates:
+  - metadata:
+      name: v1-shipa
+    spec:
+      accessModes: [ReadWriteMany]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: v2-shipa
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+---
+# Source: dashboard/templates/stateful_set.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "web"
+    theketch.io/app-process-replicas: "3"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+    theketch.io/test-label-all: "test-label-value-all"
+  name: dashboard-web-4
+spec:
+  selector:
+    matchLabels:
+      app: "dashboard"
+      version: "4"
+      theketch.io/app-name: "dashboard"
+      theketch.io/app-process: "web"
+      theketch.io/app-deployment-version: "4"
+      theketch.io/is-isolated-run: "false"
+  serviceName: "dashboard"
+  template:
+    metadata:
+      labels:
+        app: "dashboard"
+        version: "4"
+        theketch.io/app-name: "dashboard"
+        theketch.io/app-process: "web"
+        theketch.io/app-deployment-version: "4"
+        theketch.io/is-isolated-run: "false"
+    spec:
+      containers:
+        - name: dashboard-web-4
+          command: ["python"]
+          env:
+            - name: port
+              value: "9091"
+            - name: PORT
+              value: "9091"
+            - name: PORT_web
+              value: "9091"
+            - name: VAR
+              value: VALUE
+          image: shipasoftware/go-app:v2
+          ports:
+          - containerPort: 9091
+      imagePullSecrets:
+            - name: default-image-pull-secret
+  volumeClaimTemplates:
+  - metadata:
+      name: v1-shipa
+    spec:
+      accessModes: [ReadWriteMany]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: v2-shipa
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+---
+# Source: dashboard/templates/stateful_set.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+    theketch.io/app-process: "worker"
+    theketch.io/app-process-replicas: "1"
+    theketch.io/app-deployment-version: "4"
+    theketch.io/is-isolated-run: "false"
+    theketch.io/test-label-all: "test-label-value-all"
+  name: dashboard-worker-4
+spec:
+  selector:
+    matchLabels:
+      app: "dashboard"
+      version: "4"
+      theketch.io/app-name: "dashboard"
+      theketch.io/app-process: "worker"
+      theketch.io/app-deployment-version: "4"
+      theketch.io/is-isolated-run: "false"
+  serviceName: "dashboard"
+  template:
+    metadata:
+      labels:
+        app: "dashboard"
+        version: "4"
+        theketch.io/app-name: "dashboard"
+        theketch.io/app-process: "worker"
+        theketch.io/app-deployment-version: "4"
+        theketch.io/is-isolated-run: "false"
+    spec:
+      containers:
+        - name: dashboard-worker-4
+          command: ["celery"]
+          env:
+            - name: port
+              value: "9091"
+            - name: PORT
+              value: "9091"
+            - name: PORT_worker
+              value: "9091"
+            - name: VAR
+              value: VALUE
+          image: shipasoftware/go-app:v2
+          ports:
+          - containerPort: 9091
+      imagePullSecrets:
+            - name: default-image-pull-secret
+  volumeClaimTemplates:
+  - metadata:
+      name: v1-shipa
+    spec:
+      accessModes: [ReadWriteMany]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: v2-shipa
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
+---
+# Source: dashboard/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "dashboard-cname-theketch-io"
+  namespace: istio-system
+  labels:
+    theketch.io/app-name: "dashboard"
+spec:
+  secretName: dashboard-cname-theketch-io
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
+  dnsNames:
+    - theketch.io
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+---
+# Source: dashboard/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "dashboard-cname-app-theketch-io"
+  namespace: istio-system
+  labels:
+    theketch.io/app-name: "dashboard"
+spec:
+  secretName: dashboard-cname-app-theketch-io
+  secretTemplate:
+    labels:
+      theketch.io/app-name: "dashboard"
+  dnsNames:
+    - app.theketch.io
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+---
+# Source: dashboard/templates/destinationRule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-dashboard-rule-3
+  labels:
+    theketch.io/app-name: "dashboard"
+spec:
+  host: dashboard-web-3
+  subsets:
+    - name: v3
+      labels:
+        app: "dashboard"
+        version: "3"
+---
+# Source: dashboard/templates/destinationRule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-dashboard-rule-4
+  labels:
+    theketch.io/app-name: "dashboard"
+spec:
+  host: dashboard-web-4
+  subsets:
+    - name: v4
+      labels:
+        app: "dashboard"
+        version: "4"
+---
+# Source: dashboard/templates/gateway.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    theketch.io/app-name: "dashboard"
+  name: dashboard-http-gateway
+  annotations:
+    theketch.io/metadata-item-kind: Gateway
+    theketch.io/metadata-item-apiVersion: networking.istio.io/v1alpha3
+    theketch.io/gateway-annotation: "test-gateway"
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http-3
+      protocol: HTTP
+    hosts:
+    - dashboard.10.10.10.10.shipa.cloud
+  - port:
+      number: 443
+      name: https-3-theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: dashboard-cname-theketch-io
+    hosts:
+    - theketch.io
+  - port:
+      name: http-to-https-3-theketch.io
+      number: 80
+      protocol: HTTP
+    hosts:
+    - theketch.io
+    tls:
+      httpsRedirect: true
+  - port:
+      number: 443
+      name: https-3-app.theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: dashboard-cname-app-theketch-io
+    hosts:
+    - app.theketch.io
+  - port:
+      name: http-to-https-3-app.theketch.io
+      number: 80
+      protocol: HTTP
+    hosts:
+    - app.theketch.io
+    tls:
+      httpsRedirect: true
+  - port:
+      number: 443
+      name: https-3-darkweb.theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: darkweb-ssl
+    hosts:
+    - darkweb.theketch.io
+  - port:
+      name: http-to-https-3-darkweb.theketch.io
+      number: 80
+      protocol: HTTP
+    hosts:
+    - darkweb.theketch.io
+    tls:
+      httpsRedirect: true
+  - port:
+      number: 80
+      name: http-4
+      protocol: HTTP
+    hosts:
+    - dashboard.10.10.10.10.shipa.cloud
+  - port:
+      number: 443
+      name: https-4-theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: dashboard-cname-theketch-io
+    hosts:
+    - theketch.io
+  - port:
+      name: http-to-https-4-theketch.io
+      number: 80
+      protocol: HTTP
+    hosts:
+    - theketch.io
+    tls:
+      httpsRedirect: true
+  - port:
+      number: 443
+      name: https-4-app.theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: dashboard-cname-app-theketch-io
+    hosts:
+    - app.theketch.io
+  - port:
+      name: http-to-https-4-app.theketch.io
+      number: 80
+      protocol: HTTP
+    hosts:
+    - app.theketch.io
+    tls:
+      httpsRedirect: true
+  - port:
+      number: 443
+      name: https-4-darkweb.theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: darkweb-ssl
+    hosts:
+    - darkweb.theketch.io
+  - port:
+      name: http-to-https-4-darkweb.theketch.io
+      number: 80
+      protocol: HTTP
+    hosts:
+    - darkweb.theketch.io
+    tls:
+      httpsRedirect: true
+---
+# Source: dashboard/templates/virtualService.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "ingress-class"
+  labels:
+    theketch.io/app-name: "dashboard"
+  name: dashboard-http
+spec:
+    hosts:
+    - dashboard.10.10.10.10.shipa.cloud
+    - theketch.io
+    - app.theketch.io
+    - darkweb.theketch.io
+    gateways:
+    - dashboard-http-gateway
+    http:
+    - route:
+        - destination:
+            host: dashboard-web-3
+            port:
+              number: 9090
+            subset: "v3"
+          weight: 30
+        - destination:
+            host: dashboard-web-4
+            port:
+              number: 9091
+            subset: "v4"
+          weight: 70

--- a/internal/templates/common/yamls/_pod.tpl
+++ b/internal/templates/common/yamls/_pod.tpl
@@ -1,0 +1,67 @@
+{{/* Generate pod template for deployment and stateful_set */}}
+{{- define "app.podTemplate" }}
+    spec:
+      {{- if .root.app.serviceAccountName }}
+      serviceAccountName: {{ .root.app.serviceAccountName }}
+      {{- end }}
+      {{- if .root.app.securityContext }}
+      securityContext:
+{{ .root.app.securityContext | toYaml | indent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .root.app.name }}-{{ .process.name }}-{{ .deployment.version }}
+          command: {{ .process.cmd | toJson }}
+          {{- if or .process.env .root.app.env }}
+          env:
+          {{- if .process.env }}
+{{ .process.env | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .root.app.env }}
+{{ .root.app.env | toYaml | indent 12 }}
+          {{- end }}
+          {{- end }}
+          image: {{ .deployment.image }}
+          {{- if .process.containerPorts }}
+          ports:
+{{ .process.containerPorts | toYaml | indent 10 }}
+          {{- end }}
+          {{- if .process.volumeMounts }}
+          volumeMounts:
+{{ .process.volumeMounts | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .process.resourceRequirements }}
+          resources:
+{{ .process.resourceRequirements | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .process.lifecycle }}
+          lifecycle:
+{{ .process.lifecycle | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .process.securityContext }}
+          securityContext:
+{{ .process.securityContext | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .process.readinessProbe }}
+          readinessProbe:
+{{ .process.readinessProbe | toYaml | indent 12 }}
+          {{- end }}
+          {{- if .process.livenessProbe }}
+          livenessProbe:
+{{ .process.livenessProbe | toYaml | indent 12 }}
+          {{- end }}
+      {{- if .deployment.imagePullSecrets }}
+      imagePullSecrets:
+{{ .deployment.imagePullSecrets | toYaml | indent 12}}
+      {{- end }}
+      {{- if .process.volumes }}
+      volumes:
+{{ .process.volumes | toYaml | indent 12 }}
+      {{- end }}
+      {{- if .process.nodeSelectorTerms }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+{{ .process.nodeSelectorTerms | toYaml | indent 14 }}
+      {{- end }}
+{{- end }}

--- a/internal/templates/common/yamls/stateful_set.yaml
+++ b/internal/templates/common/yamls/stateful_set.yaml
@@ -1,8 +1,8 @@
-{{ if eq $.Values.app.type "Deployment" }}
+{{ if eq $.Values.app.type "StatefulSet" }}
 {{ range $_, $deployment := .Values.app.deployments }}
   {{ range $_, $process := $deployment.processes }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
@@ -21,7 +21,6 @@ metadata:
   {{- end }}
   name: {{ $.Values.app.name }}-{{ $process.name }}-{{ $deployment.version }}
 spec:
-  replicas: {{ $process.units }}
   selector:
     matchLabels:
       app: {{ default $.Values.app.name $.Values.app.id | quote }}
@@ -30,6 +29,7 @@ spec:
       {{ $.Values.app.group }}/app-process: {{ $process.name | quote }}
       {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
       {{ $.Values.app.group }}/is-isolated-run: "false"
+  serviceName: {{ $.Values.app.name | quote }}
   template:
     metadata:
       labels:
@@ -49,6 +49,19 @@ spec:
         {{- end }}
       {{- end }}
     {{- template "app.podTemplate" (dict "root" $.Values "deployment" $deployment "process" $process) }}
+  {{- if $.Values.app.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- range $_, $template := $.Values.app.volumeClaimTemplates }}
+  - metadata:
+      name: {{ $template.name }}
+    spec:
+      accessModes: {{ $template.accessModes }}
+      storageClassName: {{ $template.storageClassName | quote }}
+      resources:
+        requests:
+          storage: {{ $template.storage }}
+    {{- end }}
+  {{- end }}
 ---
 {{ end }}
 {{ end }}


### PR DESCRIPTION
# Description

Apps can now be deployed as a statefulset if the `type` in `appSpec` is specified as "StatefulSet", and `volumeClaimTemplates` are provided. The default type for apps is `deployment`.

There is some duplication in `app_controller.go` with the functions `watchStatefulSetEvents` and `watchStatefulSetFunc`. There are some minor differences between a `deployment` and a `statefulset`, that I could not get to work in one singular function.

However, both `deployment` and `statefulset` use `AppDeploymentEvent`. I'm treating an app deployment (in terms of ketch) as type independent (when it comes to statefulset versus deployment in k8s). It is possible to create unique events based on which type of deployment if need be.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
