### PR TITLE
[SHIPA-1384] skips notFound error in app watch loop

### DIFF
--- a/internal/controllers/app_controller.go
+++ b/internal/controllers/app_controller.go
@@ -571,11 +571,14 @@ func (r *AppReconciler) watchFunc(ctx context.Context, cleanup cleanupFunc, app 
 			return ctx.Err()
 		}
 
-		wl, err = cli.Get(ctx)
-		if err != nil {
+		newWorkload, err := cli.Get(ctx)
+		if err != nil && !k8sErrors.IsNotFound(err) {
 			deploymentErrorEvent := newAppDeploymentEvent(app, ketchv1.AppReconcileError, fmt.Sprintf("error getting deployments: %s", err.Error()), processName)
 			recorder.AnnotatedEventf(app, deploymentErrorEvent.Annotations, v1.EventTypeWarning, deploymentErrorEvent.Reason, deploymentErrorEvent.Description)
 			return err
+		}
+		if err == nil {
+			wl = newWorkload
 		}
 	}
 


### PR DESCRIPTION
# Description

When updating an existing app, especially via `shipa app deploy`, the app watcher loop occasionally emits a WARNING event, indicating that it cannot find the latest deployment, event though deployment does exist. It seems to be a race. It's probably fine to just skip this notFound error and let the loop run again. 

I tested this PR by building & pushing this docker image, using it w/ shipa, and re-deploying an existing app to a new framework. 

[shipa-1384]


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
