### PR TITLE
[SHIPA-2627] omit default backoffLimit value

### DIFF
--- a/ci/limits.json
+++ b/ci/limits.json
@@ -1,5 +1,5 @@
 {
-	"github.com/theketchio/ketch/cmd/ketch": 61.4,
+	"github.com/theketchio/ketch/cmd/ketch": 61.3,
 	"github.com/theketchio/ketch/cmd/ketch/configuration": 0,
 	"github.com/theketchio/ketch/cmd/ketch/output": 68.3,
 	"github.com/theketchio/ketch/cmd/manager": 0,

--- a/cmd/ketch/job_deploy.go
+++ b/cmd/ketch/job_deploy.go
@@ -23,8 +23,6 @@ Deploy a job.
 const (
 	defaultJobVersion       = "v1"
 	defaultJobParallelism   = 1
-	defaultJobCompletions   = 1
-	defaultJobBackoffLimit  = 6
 	defaultJobRestartPolicy = "Never"
 )
 
@@ -86,9 +84,6 @@ func setJobSpecDefaults(jobSpec *ketchv1.JobSpec) {
 	}
 	if jobSpec.Completions == 0 {
 		jobSpec.Completions = jobSpec.Parallelism
-	}
-	if jobSpec.BackoffLimit == 0 {
-		jobSpec.BackoffLimit = defaultJobBackoffLimit
 	}
 	if jobSpec.Policy.RestartPolicy == "" {
 		jobSpec.Policy.RestartPolicy = defaultJobRestartPolicy

--- a/cmd/ketch/job_deploy_test.go
+++ b/cmd/ketch/job_deploy_test.go
@@ -12,6 +12,7 @@ import (
 
 	ketchv1 "github.com/theketchio/ketch/internal/api/v1beta1"
 	"github.com/theketchio/ketch/internal/mocks"
+	"github.com/theketchio/ketch/internal/utils/conversions"
 )
 
 func TestJobDeploy(t *testing.T) {
@@ -59,7 +60,7 @@ policy:
 				Parallelism:  1,
 				Completions:  1,
 				Suspend:      false,
-				BackoffLimit: 6,
+				BackoffLimit: conversions.IntPtr(6),
 				Containers: []ketchv1.Container{
 					{
 						Name:    "lister",

--- a/cmd/ketch/job_export_test.go
+++ b/cmd/ketch/job_export_test.go
@@ -11,6 +11,7 @@ import (
 
 	ketchv1 "github.com/theketchio/ketch/internal/api/v1beta1"
 	"github.com/theketchio/ketch/internal/mocks"
+	"github.com/theketchio/ketch/internal/utils/conversions"
 )
 
 func TestJobExport(t *testing.T) {
@@ -24,7 +25,7 @@ func TestJobExport(t *testing.T) {
 			Parallelism:  1,
 			Completions:  1,
 			Suspend:      false,
-			BackoffLimit: 6,
+			BackoffLimit: conversions.IntPtr(6),
 			Containers: []ketchv1.Container{
 				{
 					Name:    "lister",

--- a/cmd/ketch/job_list_test.go
+++ b/cmd/ketch/job_list_test.go
@@ -11,6 +11,7 @@ import (
 
 	ketchv1 "github.com/theketchio/ketch/internal/api/v1beta1"
 	"github.com/theketchio/ketch/internal/mocks"
+	"github.com/theketchio/ketch/internal/utils/conversions"
 )
 
 func TestJobList(t *testing.T) {
@@ -24,7 +25,7 @@ func TestJobList(t *testing.T) {
 			Parallelism:  1,
 			Completions:  1,
 			Suspend:      false,
-			BackoffLimit: 6,
+			BackoffLimit: conversions.IntPtr(6),
 			Containers: []ketchv1.Container{
 				{
 					Name:    "lister",
@@ -80,7 +81,7 @@ func TestJobListNames(t *testing.T) {
 			Parallelism:  1,
 			Completions:  1,
 			Suspend:      false,
-			BackoffLimit: 6,
+			BackoffLimit: conversions.IntPtr(6),
 			Containers: []ketchv1.Container{
 				{
 					Name:    "lister",
@@ -107,6 +108,24 @@ func TestJobListNames(t *testing.T) {
 				CtrlClientObjects:    []runtime.Object{mockJob},
 				DynamicClientObjects: []runtime.Object{},
 			},
+			wantOut: []string{"hello"},
+		},
+		{
+			name: "filter",
+			cfg: &mocks.Configuration{
+				CtrlClientObjects:    []runtime.Object{mockJob},
+				DynamicClientObjects: []runtime.Object{},
+			},
+			filter:  "goodbye",
+			wantOut: []string{},
+		},
+		{
+			name: "filter",
+			cfg: &mocks.Configuration{
+				CtrlClientObjects:    []runtime.Object{mockJob},
+				DynamicClientObjects: []runtime.Object{},
+			},
+			filter:  "hello",
 			wantOut: []string{"hello"},
 		},
 	}

--- a/cmd/ketch/job_remove_test.go
+++ b/cmd/ketch/job_remove_test.go
@@ -11,6 +11,7 @@ import (
 
 	ketchv1 "github.com/theketchio/ketch/internal/api/v1beta1"
 	"github.com/theketchio/ketch/internal/mocks"
+	"github.com/theketchio/ketch/internal/utils/conversions"
 )
 
 func TestJobRemove(t *testing.T) {
@@ -24,7 +25,7 @@ func TestJobRemove(t *testing.T) {
 			Parallelism:  1,
 			Completions:  1,
 			Suspend:      false,
-			BackoffLimit: 6,
+			BackoffLimit: conversions.IntPtr(6),
 			Containers: []ketchv1.Container{
 				{
 					Name:    "lister",

--- a/config/crd/bases/theketch.io_jobs.yaml
+++ b/config/crd/bases/theketch.io_jobs.yaml
@@ -41,6 +41,7 @@ spec:
             description: JobSpec defines the desired state of Job
             properties:
               backoffLimit:
+                minimum: 0
                 type: integer
               completions:
                 type: integer

--- a/internal/api/v1beta1/job_types.go
+++ b/internal/api/v1beta1/job_types.go
@@ -22,15 +22,16 @@ import (
 
 // JobSpec defines the desired state of Job
 type JobSpec struct {
-	Version      string      `json:"version,omitempty"`
-	Type         string      `json:"type"`
-	Name         string      `json:"name"`
-	Framework    string      `json:"framework"`
-	Description  string      `json:"description,omitempty"`
-	Parallelism  int         `json:"parallelism,omitempty"`
-	Completions  int         `json:"completions,omitempty"`
-	Suspend      bool        `json:"suspend,omitempty"`
-	BackoffLimit int         `json:"backoffLimit,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	Framework   string `json:"framework"`
+	Description string `json:"description,omitempty"`
+	Parallelism int    `json:"parallelism,omitempty"`
+	Completions int    `json:"completions,omitempty"`
+	Suspend     bool   `json:"suspend,omitempty"`
+	//+kubebuilder:validation:Minimum=0
+	BackoffLimit *int        `json:"backoffLimit,omitempty"`
 	Containers   []Container `json:"containers,omitempty"`
 	Policy       Policy      `json:"policy,omitempty"`
 }

--- a/internal/api/v1beta1/job_types_test.go
+++ b/internal/api/v1beta1/job_types_test.go
@@ -1,0 +1,72 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCondition(t *testing.T) {
+	tests := []struct {
+		description   string
+		jobStatus     *JobStatus
+		conditionType ConditionType
+		expected      *Condition
+	}{
+		{
+			description:   "found",
+			jobStatus:     &JobStatus{Conditions: []Condition{{Type: "type1", Status: "active"}, {Type: "type2", Status: "failed"}}},
+			conditionType: ConditionType("type1"),
+			expected:      &Condition{Type: "type1", Status: "active"},
+		},
+		{
+			description:   "not found",
+			jobStatus:     &JobStatus{Conditions: []Condition{{Type: "type1", Status: "active"}, {Type: "type2", Status: "failed"}}},
+			conditionType: ConditionType("complete"),
+			expected:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			res := tt.jobStatus.Condition(tt.conditionType)
+			require.Equal(t, tt.expected, res)
+		})
+	}
+}
+
+func TestSetCondition(t *testing.T) {
+	now := metav1.Time{}
+	j := &Job{
+		Status: JobStatus{
+			Conditions: []Condition{
+				{
+					Type:    ConditionType("type1"),
+					Status:  "active",
+					Message: "message-1",
+				},
+			},
+		},
+	}
+	expected := &Job{
+		Status: JobStatus{
+			Conditions: []Condition{
+				{
+					Type:    ConditionType("type1"),
+					Status:  "active",
+					Message: "message-1",
+				},
+				{
+					Type:               ConditionType("type2"),
+					Status:             "failed",
+					Message:            "message-2",
+					LastTransitionTime: &now,
+				},
+			},
+		},
+	}
+
+	j.SetCondition("type2", v1.ConditionStatus("failed"), "message-2", now)
+	require.Equal(t, expected, j)
+}

--- a/internal/chart/chartutils_test.go
+++ b/internal/chart/chartutils_test.go
@@ -30,7 +30,7 @@ func TestBufferedFiles(t *testing.T) {
 				Parallelism:  2,
 				Completions:  2,
 				Suspend:      false,
-				BackoffLimit: 4,
+				BackoffLimit: conversions.IntPtr(4),
 				Containers: []ketchv1.Container{
 					{
 						Name:    "test",
@@ -105,7 +105,7 @@ func TestGetValuesMap(t *testing.T) {
 				Parallelism:  2,
 				Completions:  2,
 				Suspend:      false,
-				BackoffLimit: 4,
+				BackoffLimit: conversions.IntPtr(4),
 				Containers: []ketchv1.Container{
 					{
 						Name:    "test",

--- a/internal/chart/job_chart_test.go
+++ b/internal/chart/job_chart_test.go
@@ -9,6 +9,7 @@ import (
 
 	ketchv1 "github.com/theketchio/ketch/internal/api/v1beta1"
 	"github.com/theketchio/ketch/internal/templates"
+	"github.com/theketchio/ketch/internal/utils/conversions"
 )
 
 var (
@@ -25,7 +26,7 @@ var (
 			Parallelism:  2,
 			Completions:  2,
 			Suspend:      false,
-			BackoffLimit: 4,
+			BackoffLimit: conversions.IntPtr(4),
 			Containers: []ketchv1.Container{
 				{
 					Name:    "test",

--- a/internal/templates/job/yamls/job.yaml
+++ b/internal/templates/job/yamls/job.yaml
@@ -12,7 +12,7 @@ spec:
   {{- if $.Values.job.completions }}
   completions: {{ $.Values.job.completions }}
   {{- end }}
-  {{- if $.Values.job.backoffLimit }}
+  {{- if not (kindIs "invalid" $.Values.job.backoffLimit) }}
   backoffLimit: {{ $.Values.job.backoffLimit }}
   {{- end }}
   {{- if $.Values.job.suspend }}


### PR DESCRIPTION
# Description

Removes redundant `defaultBackoffLimit` from CLI. K8s sets the default to 6 when empty. Makes `backoffLimit` a pointer, permitting passing a `0` in. 


Fixes # shipa-2627

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
