### PR TITLE
Remove dependany on deprecated ingress class annotation

### DIFF
--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -411,12 +411,12 @@ kind: Ingress
 metadata:
   name: dashboard-0-https-ingress
   annotations:
-    kubernetes.io/ingress.class: "ingress-class"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   labels:
     theketch.io/app-name: "dashboard"
 spec:
+  ingressClassName: "ingress-class"
   tls:
     - hosts:
         - theketch.io
@@ -465,7 +465,6 @@ kind: Ingress
 metadata:
   name: dashboard-1-https-ingress
   annotations:
-    kubernetes.io/ingress.class: "ingress-class"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/canary: "true"
@@ -473,6 +472,7 @@ metadata:
   labels:
     theketch.io/app-name: "dashboard"
 spec:
+  ingressClassName: "ingress-class"
   tls:
     - hosts:
         - theketch.io

--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -361,13 +361,13 @@ kind: Ingress
 metadata:
   name: dashboard-0-http-ingress
   annotations:
-    kubernetes.io/ingress.class: "ingress-class"
     theketch.io/metadata-item-kind: Ingress
     theketch.io/metadata-item-apiVersion: networking.k8s.io/v1
     theketch.io/ingress-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
 spec:
+  ingressClassName: "ingress-class"
   rules:
   - host: dashboard.10.10.10.10.shipa.cloud
     http:
@@ -385,7 +385,6 @@ kind: Ingress
 metadata:
   name: dashboard-1-http-ingress
   annotations:
-    kubernetes.io/ingress.class: "ingress-class"
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "70"
     theketch.io/metadata-item-kind: Ingress
@@ -394,6 +393,7 @@ metadata:
   labels:
     theketch.io/app-name: "dashboard"
 spec:
+  ingressClassName: "ingress-class"
   rules:
   - host: dashboard.10.10.10.10.shipa.cloud
     http:

--- a/internal/chart/testdata/charts/dashboard-nginx.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx.yaml
@@ -365,13 +365,13 @@ kind: Ingress
 metadata:
   name: dashboard-0-http-ingress
   annotations:
-    kubernetes.io/ingress.class: "gke"
     theketch.io/metadata-item-kind: Ingress
     theketch.io/metadata-item-apiVersion: networking.k8s.io/v1
     theketch.io/ingress-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
 spec:
+  ingressClassName: "gke"
   rules:
   - host: theketch.io
     http:
@@ -416,7 +416,6 @@ kind: Ingress
 metadata:
   name: dashboard-1-http-ingress
   annotations:
-    kubernetes.io/ingress.class: "gke"
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "70"
     theketch.io/metadata-item-kind: Ingress
@@ -425,6 +424,7 @@ metadata:
   labels:
     theketch.io/app-name: "dashboard"
 spec:
+  ingressClassName: "gke"
   rules:
   - host: theketch.io
     http:

--- a/internal/templates/nginx/yamls/ingress.yaml
+++ b/internal/templates/nginx/yamls/ingress.yaml
@@ -50,9 +50,6 @@ kind: Ingress
 metadata:
   name: {{ $.Values.app.name }}-{{ $i }}-https-ingress
   annotations:
-    {{- if $.Values.ingressController.className }}
-    kubernetes.io/ingress.class: {{ $.Values.ingressController.className | quote }}
-    {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- if gt $i 0 }}
@@ -62,6 +59,9 @@ metadata:
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
+  {{- if $.Values.ingressController.className }}
+  ingressClassName: {{ $.Values.ingressController.className | quote }}
+  {{- end }}
   tls:
     {{- range $_, $https := $.Values.app.ingress.https }}
     - hosts:

--- a/internal/templates/nginx/yamls/ingress.yaml
+++ b/internal/templates/nginx/yamls/ingress.yaml
@@ -7,9 +7,6 @@ kind: Ingress
 metadata:
   name: {{ $.Values.app.name }}-{{ $i }}-http-ingress
   annotations:
-    {{- if $.Values.ingressController.className }}
-    kubernetes.io/ingress.class: {{ $.Values.ingressController.className | quote }}
-    {{- end }}
     {{- if gt $i 0 }}
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "{{ $deployment.routingSettings.weight }}"
@@ -19,6 +16,9 @@ metadata:
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:
+  {{- if $.Values.ingressController.className }}
+  ingressClassName: {{ $.Values.ingressController.className | quote }}
+  {{- end }}
   rules:
   {{- range $_, $cname := $.Values.app.ingress.http }}
   - host: {{ $cname }}


### PR DESCRIPTION
# Description

Remove dependency on deprecated ingress.class annotation
Use ingressClassname spec field instead

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
