### PR TITLE
[SHIPA-2788] Annotates events with Pod Name in the event of a Error type event

### DIFF
--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -1009,7 +1009,8 @@ const (
 	DeploymentAnnotationInvolvedObjectName      = "deployment.shipa.io/involved-object-name"
 	DeploymentAnnotationInvolvedObjectFieldPath = "deployment.shipa.io/involved-object-field-path"
 	DeploymentAnnotationSourceHost              = "deployment.shipa.io/source-host"
-	DeploymentAnnotationSourceComponent         = "deployment.shipa.io/cource-component"
+	DeploymentAnnotationSourceComponent         = "deployment.shipa.io/source-component"
+	DeploymentAnnotationPodErrorName            = "deployment.shipa.io/pod-error-name"
 
 	AppReconcileStarted  = "AppReconcileStarted"
 	AppReconcileComplete = "AppReconcileComplete"
@@ -1036,6 +1037,7 @@ type AppDeploymentEvent struct {
 	// Source is the source of an incoming event
 	SourceHost      string
 	SourceComponent string
+	PodErrorName    string
 }
 
 func AppDeploymentEventFromAnnotations(annotations map[string]string) *AppDeploymentEvent {

--- a/internal/controllers/app_controller.go
+++ b/internal/controllers/app_controller.go
@@ -271,7 +271,6 @@ func (cli workloadClient) Get(ctx context.Context) (*workload, error) {
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println("...workload status", o.Status)
 		w := workload{
 			Name:               o.Name,
 			UpdatedReplicas:    int(o.Status.UpdatedReplicas),
@@ -373,7 +372,7 @@ func (r *AppReconciler) reconcile(ctx context.Context, app *ketchv1.App, logger 
 		}
 
 		// retry until all pods for canary deployment comes to running state.
-		if _, err := checkPodStatus(r.Group, r.Client, app.Name, app.Spec.Deployments[1].Version); err != nil {
+		if _, err := checkPodStatus(r.Group, r.Client, app.Name, app.Spec.Deployments[1].Version); len(app.Spec.Deployments) > 1 && err != nil {
 
 			if !timeoutExpired(app.Spec.Canary.Started, r.Now()) {
 				return appReconcileResult{
@@ -689,7 +688,6 @@ func createDeployTimeoutError(ctx context.Context, cli kubernetes.Interface, app
 		deploymentVersion = int(app.Spec.Deployments[len(app.Spec.Deployments)-1].Version)
 	}
 	opts := metav1.ListOptions{
-		//FieldSelector: "involvedObject.kind=Pod",
 		LabelSelector: fmt.Sprintf("%s/app-name=%s,%s/app-deployment-version=%d", group, app.Name, group, deploymentVersion),
 	}
 	pods, err := cli.CoreV1().Pods(app.GetNamespace()).List(ctx, opts)


### PR DESCRIPTION
# Description

Shipa would like to emit app.error Shipa events when there is a deployment error via kubernetes. It would be helpful to have one of the offending pods for this. This PR uses the existing `getPodStatus` func to get the podName, which is then included in the K8s event as an annotation. 

Fixes # shipa-2788

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
