### PR TITLE
Move application readiness wait loop inside goroutine

### DIFF
--- a/internal/controllers/app_controller_test.go
+++ b/internal/controllers/app_controller_test.go
@@ -233,7 +233,7 @@ func TestAppReconciler_Reconcile(t *testing.T) {
 	require.Equal(t, []string{"app-running"}, helmMock.deleteChartCalled)
 }
 
-func TestWatchDeployEventsError(t *testing.T) {
+func TestInitWatcherError(t *testing.T) {
 	process := &ketchv1.ProcessSpec{
 		Name: "test",
 	}
@@ -268,16 +268,14 @@ func TestWatchDeployEventsError(t *testing.T) {
 		k8sClient: cli,
 	}
 	recorder := record.NewFakeRecorder(1024)
-	r := AppReconciler{
-		CancelMap: NewCancelMap(),
-	}
+
 	var events []string
 	go func() {
 		for ev := range recorder.Events {
 			events = append(events, ev)
 		}
 	}()
-	err := r.watchDeployEvents(context.Background(), app, wc, wl, process, recorder)
+	_, err := initWatcher(context.Background(), app, wc, wl, process, recorder)
 	require.EqualError(t, err, "assure clusterrole 'manager-role' has 'watch' permissions on event resources: unknown (get events)")
 	time.Sleep(time.Millisecond * 100) // give events time to propagate
 	require.Equal(t, 1, len(events))


### PR DESCRIPTION
# Description

Ketch gets stuck in a 10 minute loop when we deploy a `statefulset` with an error. Example `ketch app deploy testapp -k dev -i docker.io/shipasoftware/bulletinboard:1.0 --volume aaa/bbb` (malformed volume).

Unlike `deployments`, a `statefulset` with this error (and possibly others) never reaches a first `status.observedGeneration`. As a result, we sit in a loop waiting to proceed to kicking off the eventWatcher goroutine (watches Pod Events and emits Shipa Events). This blocks the reconciler, making it difficult for users to remove the bad application.

This PR moves the `observedGeneration` wait inside the goroutine.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
