### PR TITLE
Add deployment version label to all resources

### DIFF
--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer-pod-security-context.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer-pod-security-context.yaml
@@ -375,6 +375,7 @@ metadata:
   namespace: istio-system
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: dashboard-cname-theketch-io
   secretTemplate:
@@ -394,6 +395,7 @@ metadata:
   namespace: istio-system
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: dashboard-cname-app-theketch-io
   secretTemplate:
@@ -412,6 +414,7 @@ metadata:
   name: shipa-dashboard-rule-3
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "3"
 spec:
   host: dashboard-web-3
   subsets:
@@ -427,6 +430,7 @@ metadata:
   name: shipa-dashboard-rule-4
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   host: dashboard-web-4
   subsets:
@@ -441,6 +445,7 @@ kind: Gateway
 metadata:
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http-gateway
   annotations:
     theketch.io/metadata-item-kind: Gateway
@@ -573,6 +578,7 @@ metadata:
     kubernetes.io/ingress.class: "ingress-class"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http
 spec:
     hosts:

--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer-volume-claim-templates.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer-volume-claim-templates.yaml
@@ -431,6 +431,7 @@ metadata:
   namespace: istio-system
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: dashboard-cname-theketch-io
   secretTemplate:
@@ -450,6 +451,7 @@ metadata:
   namespace: istio-system
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: dashboard-cname-app-theketch-io
   secretTemplate:
@@ -468,6 +470,7 @@ metadata:
   name: shipa-dashboard-rule-3
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "3"
 spec:
   host: dashboard-web-3
   subsets:
@@ -483,6 +486,7 @@ metadata:
   name: shipa-dashboard-rule-4
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   host: dashboard-web-4
   subsets:
@@ -497,6 +501,7 @@ kind: Gateway
 metadata:
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http-gateway
   annotations:
     theketch.io/metadata-item-kind: Gateway
@@ -629,6 +634,7 @@ metadata:
     kubernetes.io/ingress.class: "ingress-class"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http
 spec:
     hosts:

--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -363,6 +363,7 @@ metadata:
   namespace: istio-system
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: dashboard-cname-theketch-io
   secretTemplate:
@@ -382,6 +383,7 @@ metadata:
   namespace: istio-system
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: dashboard-cname-app-theketch-io
   secretTemplate:
@@ -400,6 +402,7 @@ metadata:
   name: shipa-dashboard-rule-3
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "3"
 spec:
   host: dashboard-web-3
   subsets:
@@ -415,6 +418,7 @@ metadata:
   name: shipa-dashboard-rule-4
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   host: dashboard-web-4
   subsets:
@@ -429,6 +433,7 @@ kind: Gateway
 metadata:
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http-gateway
   annotations:
     theketch.io/metadata-item-kind: Gateway
@@ -561,6 +566,7 @@ metadata:
     kubernetes.io/ingress.class: "ingress-class"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http
 spec:
     hosts:

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -362,6 +362,7 @@ metadata:
   name: shipa-dashboard-rule-3
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "3"
 spec:
   host: dashboard-web-3
   subsets:
@@ -377,6 +378,7 @@ metadata:
   name: shipa-dashboard-rule-4
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   host: dashboard-web-4
   subsets:
@@ -391,6 +393,7 @@ kind: Gateway
 metadata:
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http-gateway
   annotations:
     theketch.io/metadata-item-kind: Gateway
@@ -427,6 +430,7 @@ metadata:
     kubernetes.io/ingress.class: "gke"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
   name: dashboard-http
 spec:
     hosts:

--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -366,6 +366,7 @@ metadata:
     theketch.io/ingress-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "3"
 spec:
   ingressClassName: "ingress-class"
   rules:
@@ -392,6 +393,7 @@ metadata:
     theketch.io/ingress-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   ingressClassName: "ingress-class"
   rules:
@@ -522,6 +524,7 @@ metadata:
   name: "dashboard-cname-theketch-io"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: "dashboard-cname-theketch-io"
   secretTemplate:
@@ -540,6 +543,7 @@ metadata:
   name: "dashboard-cname-app-theketch-io"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
   secretTemplate:

--- a/internal/chart/testdata/charts/dashboard-nginx.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx.yaml
@@ -370,6 +370,7 @@ metadata:
     theketch.io/ingress-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "3"
 spec:
   ingressClassName: "gke"
   rules:
@@ -423,6 +424,7 @@ metadata:
     theketch.io/ingress-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   ingressClassName: "gke"
   rules:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -362,6 +362,7 @@ metadata:
   name: "dashboard-cname-theketch-io"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   secretName: "dashboard-cname-theketch-io"
   secretTemplate:
@@ -380,6 +381,7 @@ metadata:
   name: "dashboard-cname-app-theketch-io"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
   secretTemplate:
@@ -404,6 +406,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web
@@ -431,6 +434,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - websecure
@@ -460,6 +464,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web
@@ -489,6 +494,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - websecure
@@ -518,6 +524,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web
@@ -547,6 +554,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - websecure
@@ -576,6 +584,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     shipa.io/app-name: "dashboard"
+    shipa.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -362,6 +362,7 @@ metadata:
   name: "dashboard-cname-theketch-io"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: "dashboard-cname-theketch-io"
   secretTemplate:
@@ -380,6 +381,7 @@ metadata:
   name: "dashboard-cname-app-theketch-io"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   secretName: "dashboard-cname-app-theketch-io"
   secretTemplate:
@@ -404,6 +406,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web
@@ -431,6 +434,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - websecure
@@ -460,6 +464,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web
@@ -489,6 +494,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - websecure
@@ -518,6 +524,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web
@@ -547,6 +554,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - websecure
@@ -576,6 +584,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web

--- a/internal/chart/testdata/charts/dashboard-traefik.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik.yaml
@@ -367,6 +367,7 @@ metadata:
     theketch.io/ingress-route-annotation: "test-ingress"
   labels:
     theketch.io/app-name: "dashboard"
+    theketch.io/app-deployment-version: "4"
 spec:
   entryPoints:
     - web

--- a/internal/templates/istio/yamls/certificate.yaml
+++ b/internal/templates/istio/yamls/certificate.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: istio-system
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
 spec:
   secretName: {{ $https.secretName }}
   secretTemplate:

--- a/internal/templates/istio/yamls/destinationRule.yaml
+++ b/internal/templates/istio/yamls/destinationRule.yaml
@@ -7,6 +7,7 @@ metadata:
   name: shipa-{{ $.Values.app.name}}-rule-{{ $deployment.version }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
 spec:
   host: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
   subsets:

--- a/internal/templates/istio/yamls/gateway.yaml
+++ b/internal/templates/istio/yamls/gateway.yaml
@@ -5,6 +5,9 @@ kind: Gateway
 metadata:
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
   name: {{ $.Values.app.name }}-http-gateway
   {{- $data := dict "kind" "Gateway" "apiVersion" "networking.istio.io/v1alpha3" "metadataItems" $.Values.app.metadataAnnotations }}
   annotations: {{- include "ketch.renderMetadata" $data | nindent 4 }}

--- a/internal/templates/istio/yamls/virtualService.yaml
+++ b/internal/templates/istio/yamls/virtualService.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- end }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
   name: {{ $.Values.app.name }}-http
 spec:
     hosts:

--- a/internal/templates/nginx/yamls/certificate.yaml
+++ b/internal/templates/nginx/yamls/certificate.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ $https.secretName | quote }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
 spec:
   secretName: {{ $https.secretName | quote }}
   secretTemplate:

--- a/internal/templates/nginx/yamls/ingress.yaml
+++ b/internal/templates/nginx/yamls/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- include "ketch.renderMetadata" $data | nindent 4 }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
 spec:
   {{- if $.Values.ingressController.className }}
   ingressClassName: {{ $.Values.ingressController.className | quote }}

--- a/internal/templates/traefik/yamls/certificate.yaml
+++ b/internal/templates/traefik/yamls/certificate.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ $https.secretName | quote }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
 spec:
   secretName: {{ $https.secretName | quote }}
   secretTemplate:

--- a/internal/templates/traefik/yamls/http-ingress-route.yaml
+++ b/internal/templates/traefik/yamls/http-ingress-route.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- include "ketch.renderMetadata" $data | nindent 4 }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
 spec:
   entryPoints:
     - web

--- a/internal/templates/traefik/yamls/https-ingress-routes.yaml
+++ b/internal/templates/traefik/yamls/https-ingress-routes.yaml
@@ -25,6 +25,9 @@ metadata:
     {{- include "ketch.renderMetadata" $data | nindent 4 }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
 spec:
   entryPoints:
     - websecure
@@ -61,6 +64,9 @@ metadata:
     {{- include "ketch.renderMetadata" $data | nindent 4 }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
+    {{- with (last $.Values.app.deployments) }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ .version | quote }}
+    {{- end }}
 spec:
   entryPoints:
     - web


### PR DESCRIPTION
# Description

In order for some specific resource version to be target of patch, we want to add label to which deployment version each resource belongs

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
