### PR TITLE
[Shipa-2871] Adds volume name validators

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -256,15 +256,22 @@ func deployImage(ctx context.Context, svc *Services, app *ketchv1.App, params *C
 		return err
 	}
 
+	volume, _ := params.getVolumeName()
+	volumeMounts, _ := params.getVolumeMounts()
+	volumes, _ := params.getVolumes()
+	for _, volume := range volumes {
+		_, err = svc.KubeClient.CoreV1().PersistentVolumeClaims(framework.Spec.NamespaceName).Get(ctx, volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrap(err, "create pvc or input correct pvc name")
+		}
+	}
+
 	steps, _ := params.getSteps()
 	stepWeight, _ := params.getStepWeight()
 	interval, _ := params.getStepInterval()
 	units, _ := params.getUnits()
 	version, _ := params.getVersion()
 	process, _ := params.getProcess()
-	volume, _ := params.getVolumeName()
-	volumes, _ := params.getVolumes()
-	volumeMounts, _ := params.getVolumeMounts()
 
 	currentTime := time.Now()
 

--- a/internal/deploy/parameters.go
+++ b/internal/deploy/parameters.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
@@ -400,6 +402,11 @@ func (c *ChangeSet) getVolumeName() (string, error) {
 	if c.volume == nil {
 		return "", newMissingError(FlagVolume)
 	}
+	if errs := validation.IsDNS1123Label(*c.volume); len(errs) > 0 {
+		return "", fmt.Errorf("%w %s, %s",
+			newInvalidValueError(FlagVolume), FlagVolume, strings.Join(errs[:], ","))
+	}
+
 	return *c.volume, nil
 }
 

--- a/internal/deploy/parameters_test.go
+++ b/internal/deploy/parameters_test.go
@@ -75,6 +75,11 @@ func TestChangeSet_getVolumeName(t *testing.T) {
 			set:     ChangeSet{},
 			wantErr: `"volume" missing`,
 		},
+		{
+			name:    "invalid volume name",
+			set:     ChangeSet{volume: stringRef("aaa/bbb")},
+			wantErr: `"volume" invalid value volume, a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

This PR focuses on extra validation checks for volumes

1. A compliant k8 volume name (conforms to the following regex: `"[a-z0-9]([-a-z0-9]*[a-z0-9])?"`)
2. Explicitly checking that the pvc exists via a k8 call and erroring if it does not

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
