### PR TITLE
Override app namespace

### DIFF
--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -2385,6 +2385,9 @@ spec:
                       type: object
                   type: object
                 type: array
+              namespace:
+                description: Namespace overrides the App's Framework's Namespace
+                type: string
               securityContext:
                 description: SecurityContext specifies security settings for a pod/app,
                   which get applied to all containers.

--- a/config/crd/bases/theketch.io_jobs.yaml
+++ b/config/crd/bases/theketch.io_jobs.yaml
@@ -69,6 +69,8 @@ spec:
                 type: string
               name:
                 type: string
+              namespace:
+                type: string
               parallelism:
                 type: integer
               policy:

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -674,7 +674,7 @@ func (app *App) AddLabel(label map[string]string, target Target) {
 		if app.Spec.Labels[i].Target != target {
 			continue
 		}
-		for key := range app.Spec.Labels[i].Apply {
+		for key := range label {
 			delete(app.Spec.Labels[i].Apply, key)
 		}
 		if len(app.Spec.Labels[i].Apply) == 0 {

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -667,6 +667,34 @@ func (app *App) DoRollback() {
 	app.Spec.Canary.Active = false
 }
 
+// AddLabel adds a label to an app's deployments' processes. It will remove labels with matching keys and targets.
+func (app *App) AddLabel(label map[string]string, target Target) {
+	// clean up labels
+	for i := len(app.Spec.Labels) - 1; i >= 0; i-- {
+		if app.Spec.Labels[i].Target != target {
+			continue
+		}
+		for key := range app.Spec.Labels[i].Apply {
+			delete(app.Spec.Labels[i].Apply, key)
+		}
+		if len(app.Spec.Labels[i].Apply) == 0 {
+			app.Spec.Labels = append(app.Spec.Labels[:i], app.Spec.Labels[i+1:]...)
+		}
+	}
+
+	// add labels
+	for _, deployment := range app.Spec.Deployments {
+		for _, process := range deployment.Processes {
+			app.Spec.Labels = append(app.Spec.Labels, MetadataItem{
+				Target:            target,
+				ProcessName:       process.Name,
+				DeploymentVersion: int(deployment.Version),
+				Apply:             label,
+			})
+		}
+	}
+}
+
 // PodState describes the simplified state of a pod in the cluster
 type PodState string
 

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -234,6 +234,9 @@ type AppSpec struct {
 	// Annotations is a list of annotations that will be applied to Services/Deployments/Pods/Gateways/Ingresses/IngressRoutes.
 	Annotations []MetadataItem `json:"annotations,omitempty"`
 
+	// Namespace overrides the App's Framework's Namespace
+	Namespace string `json:"namespace,omitempty"`
+
 	// ServiceAccountName specifies a service account name to be used for this application.
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -1301,6 +1301,12 @@ func TestAppAddLabel(t *testing.T) {
 							Target:            Target{Kind: "Deployment", APIVersion: "v1"},
 							ProcessName:       "process-1",
 						},
+						{
+							Apply:             map[string]string{"anotherkey": "myRETAINEDvalue"},
+							DeploymentVersion: 1,
+							Target:            Target{Kind: "Pod", APIVersion: "v1"},
+							ProcessName:       "process-1",
+						},
 					},
 				},
 			},
@@ -1311,6 +1317,12 @@ func TestAppAddLabel(t *testing.T) {
 					Apply:             map[string]string{"mykey": "myDEPLOYMENTvalue"},
 					DeploymentVersion: 1,
 					Target:            Target{Kind: "Deployment", APIVersion: "v1"},
+					ProcessName:       "process-1",
+				},
+				{
+					Apply:             map[string]string{"anotherkey": "myRETAINEDvalue"},
+					DeploymentVersion: 1,
+					Target:            Target{Kind: "Pod", APIVersion: "v1"},
 					ProcessName:       "process-1",
 				},
 				{
@@ -1328,7 +1340,6 @@ func TestAppAddLabel(t *testing.T) {
 			fmt.Println(tc.expected)
 			fmt.Println(tc.app.Spec.Labels)
 			require.EqualValues(t, tc.expected, tc.app.Spec.Labels)
-
 		})
 	}
 }

--- a/internal/api/v1beta1/job_types.go
+++ b/internal/api/v1beta1/job_types.go
@@ -26,6 +26,7 @@ type JobSpec struct {
 	Type        string `json:"type"`
 	Name        string `json:"name"`
 	Framework   string `json:"framework"`
+	Namespace   string `json:"namespace,omitempty"`
 	Description string `json:"description,omitempty"`
 	Parallelism int    `json:"parallelism,omitempty"`
 	Completions int    `json:"completions,omitempty"`

--- a/internal/chart/testdata/render_yamls/annotations-patch.yaml
+++ b/internal/chart/testdata/render_yamls/annotations-patch.yaml
@@ -2,5 +2,5 @@
   path: /metadata/annotations/app
   value: "app1"
 - op: add
-  path: /metadata/annotations/shipa.io~1is-shipa
+  path: /metadata/annotations/theketch.io~1is-shipa
   value: "true"

--- a/internal/chart/testdata/render_yamls/annotations-postrender.yaml
+++ b/internal/chart/testdata/render_yamls/annotations-postrender.yaml
@@ -46,7 +46,7 @@ kind: Deployment
 metadata:
   annotations:
     app: app1
-    theketch.io/is-shipa: "true"
+    shipa.io/is-shipa: "true"
   labels:
     theketch.io/app-deployment-version: "1"
     theketch.io/app-name: post

--- a/internal/chart/testdata/render_yamls/annotations-postrender.yaml
+++ b/internal/chart/testdata/render_yamls/annotations-postrender.yaml
@@ -46,7 +46,7 @@ kind: Deployment
 metadata:
   annotations:
     app: app1
-    shipa.io/is-shipa: "true"
+    theketch.io/is-shipa: "true"
   labels:
     theketch.io/app-deployment-version: "1"
     theketch.io/app-name: post

--- a/internal/controllers/app_controller_test.go
+++ b/internal/controllers/app_controller_test.go
@@ -924,7 +924,6 @@ func TestUpdateNamespaceLabelsForIngress(t *testing.T) {
 	tests := []struct {
 		description       string
 		app               *ketchv1.App
-		expectedLabels    map[string]string
 		expectedAppLabels []ketchv1.MetadataItem
 		expectedError     string
 	}{
@@ -943,7 +942,6 @@ func TestUpdateNamespaceLabelsForIngress(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "app-1", Namespace: "test-1"},
 			},
-			expectedLabels: map[string]string{"istio-injection": "enabled", "kubernetes.io/metadata.name": "test-1"},
 			expectedAppLabels: []ketchv1.MetadataItem{{
 				Apply:             map[string]string{"sidecar.istio.io/inject": "true"},
 				DeploymentVersion: 1,
@@ -966,7 +964,6 @@ func TestUpdateNamespaceLabelsForIngress(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "app-2", Namespace: "test-2"},
 			},
-			expectedLabels: map[string]string{"kubernetes.io/metadata.name": "test-2"},
 			expectedAppLabels: []ketchv1.MetadataItem{{
 				Apply:             map[string]string{"sidecar.istio.io/inject": "false"},
 				DeploymentVersion: 1,
@@ -993,7 +990,6 @@ func TestUpdateNamespaceLabelsForIngress(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "app-3", Namespace: "test-3"},
 			},
-			expectedLabels: map[string]string{"kubernetes.io/metadata.name": "test-3"},
 			expectedAppLabels: []ketchv1.MetadataItem{{
 				Apply:             map[string]string{"sidecar.istio.io/inject": "false"},
 				DeploymentVersion: 1,
@@ -1023,6 +1019,7 @@ func TestUpdateNamespaceLabelsForIngress(t *testing.T) {
 				require.EqualError(t, err, tc.expectedError)
 				return
 			}
+			require.Equal(t, tc.expectedAppLabels, tc.app.Spec.Labels)
 		})
 	}
 }

--- a/internal/controllers/app_controller_test.go
+++ b/internal/controllers/app_controller_test.go
@@ -874,3 +874,170 @@ func Test_appReconcileResult_isConflictError(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateNamespaceLabelsForIngress(t *testing.T) {
+	defaultObjects := []client.Object{
+		&ketchv1.Framework{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "istio-framework",
+			},
+			Spec: ketchv1.FrameworkSpec{
+				NamespaceName: "hello",
+				AppQuotaLimit: conversions.IntPtr(100),
+				IngressController: ketchv1.IngressControllerSpec{
+					IngressType: ketchv1.IstioIngressControllerType,
+				},
+			},
+		},
+		&ketchv1.Framework{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "traefik-framework",
+			},
+			Spec: ketchv1.FrameworkSpec{
+				NamespaceName: "second-namespace",
+				AppQuotaLimit: conversions.IntPtr(1),
+				IngressController: ketchv1.IngressControllerSpec{
+					IngressType: ketchv1.TraefikIngressControllerType,
+				},
+			},
+		},
+	}
+	helmMock := &helm{
+		updateChartResults: map[string]error{
+			"app-update-chart-failed": errors.New("render error"),
+		},
+	}
+	readerMock := &templateReader{
+		templatesErrors: map[string]error{
+			"templates-failed": errors.New("no templates"),
+		},
+	}
+	ctx, err := setup(readerMock, helmMock, defaultObjects)
+	require.Nil(t, err)
+	require.NotNil(t, ctx)
+	defer teardown(ctx)
+
+	r := &AppReconciler{
+		Client: ctx.k8sClient,
+	}
+
+	tests := []struct {
+		description       string
+		app               *ketchv1.App
+		namespace         *v1.Namespace
+		expectedLabels    map[string]string
+		expectedAppLabels []ketchv1.MetadataItem
+		expectedError     string
+	}{
+		{
+			description: "istio",
+			app: &ketchv1.App{
+				Spec: ketchv1.AppSpec{
+					Namespace: "test-1",
+					Framework: "istio-framework",
+					Deployments: []ketchv1.AppDeploymentSpec{{
+						Version: 1,
+						Processes: []ketchv1.ProcessSpec{{
+							Name: "process-1",
+						}},
+					}},
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "app-1", Namespace: "test-1"},
+			},
+			namespace:      &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-1"}},
+			expectedLabels: map[string]string{"istio-injection": "enabled", "kubernetes.io/metadata.name": "test-1"},
+			expectedAppLabels: []ketchv1.MetadataItem{{
+				Apply:             map[string]string{"sidecar.istio.io/inject": "true"},
+				DeploymentVersion: 1,
+				Target:            ketchv1.Target{Kind: "Pod", APIVersion: "v1"},
+				ProcessName:       "process-1",
+			}},
+		},
+		{
+			description: "non-istio",
+			app: &ketchv1.App{
+				Spec: ketchv1.AppSpec{
+					Namespace: "test-2",
+					Framework: "traefik-framework",
+					Deployments: []ketchv1.AppDeploymentSpec{{
+						Version: 1,
+						Processes: []ketchv1.ProcessSpec{{
+							Name: "process-1",
+						}},
+					}},
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "app-2", Namespace: "test-2"},
+			},
+			namespace:      &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-2"}},
+			expectedLabels: map[string]string{"kubernetes.io/metadata.name": "test-2"},
+			expectedAppLabels: []ketchv1.MetadataItem{{
+				Apply:             map[string]string{"sidecar.istio.io/inject": "false"},
+				DeploymentVersion: 1,
+				Target:            ketchv1.Target{Kind: "Pod", APIVersion: "v1"},
+				ProcessName:       "process-1",
+			}},
+		},
+		{
+			description: "non-istio - clean up old labels",
+			app: &ketchv1.App{
+				Spec: ketchv1.AppSpec{
+					Namespace: "test-3",
+					Framework: "traefik-framework",
+					Deployments: []ketchv1.AppDeploymentSpec{{
+						Version: 1,
+						Processes: []ketchv1.ProcessSpec{{
+							Name: "process-1",
+						}},
+					}},
+					Labels: []ketchv1.MetadataItem{{
+						Target: ketchv1.Target{Kind: "Pod", APIVersion: "v1"},
+						Apply:  map[string]string{"sidecar.istio.io/inject": "true"},
+					}},
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "app-3", Namespace: "test-3"},
+			},
+			namespace:      &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-3", Labels: map[string]string{"istio-injection": "enabled"}}},
+			expectedLabels: map[string]string{"kubernetes.io/metadata.name": "test-3"},
+			expectedAppLabels: []ketchv1.MetadataItem{{
+				Apply:             map[string]string{"sidecar.istio.io/inject": "false"},
+				DeploymentVersion: 1,
+				Target:            ketchv1.Target{Kind: "Pod", APIVersion: "v1"},
+				ProcessName:       "process-1",
+			}},
+		},
+		{
+			description: "non-existent namespace",
+			app: &ketchv1.App{
+				Spec: ketchv1.AppSpec{
+					Namespace: "test-3",
+					Framework: "nonexistent-framework",
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "app-4", Namespace: "test-10000000"},
+			},
+			namespace:     &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-4"}},
+			expectedError: "frameworks.theketch.io \"nonexistent-framework\" not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			err = ctx.k8sClient.Create(ctx, tc.namespace)
+			require.Nil(t, err)
+			defer ctx.k8sClient.Delete(ctx, tc.namespace)
+
+			err = r.UpdateAppNamespaceLabelsForIngress(ctx, tc.app)
+			if tc.expectedError == "" {
+				require.Nil(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedError)
+				return
+			}
+
+			var resultNamespace v1.Namespace
+			err = ctx.k8sClient.Get(context.Background(), types.NamespacedName{Namespace: tc.namespace.Namespace, Name: tc.namespace.Name}, &resultNamespace)
+			require.Nil(t, err)
+			require.Equal(t, tc.expectedLabels, resultNamespace.Labels)
+			require.Equal(t, tc.expectedAppLabels, tc.app.Spec.Labels)
+		})
+	}
+}

--- a/internal/controllers/job_controller.go
+++ b/internal/controllers/job_controller.go
@@ -129,10 +129,10 @@ func (r *JobReconciler) reconcile(ctx context.Context, job *ketchv1.Job) reconci
 			message: err.Error(),
 		}
 	}
-	if framework.Status.Namespace == nil {
+	if framework.Status.Namespace == nil && job.Spec.Namespace == "" {
 		return reconcileResult{
 			status:  v1.ConditionFalse,
-			message: fmt.Sprintf(`framework "%s" is not linked to a kubernetes namespace`, framework.Name),
+			message: fmt.Sprintf(`framework "%s" or job "%s" is not linked to a kubernetes namespace`, framework.Name, job.Name),
 		}
 	}
 	tpls, err := r.TemplateReader.Get(templates.JobConfigMapName())
@@ -163,6 +163,9 @@ func (r *JobReconciler) reconcile(ctx context.Context, job *ketchv1.Job) reconci
 	}
 
 	targetNamespace := framework.Status.Namespace.Name
+	if job.Spec.Namespace != "" {
+		targetNamespace = job.Spec.Namespace
+	}
 	helmClient, err := r.HelmFactoryFn(targetNamespace)
 	if err != nil {
 		return reconcileResult{
@@ -197,7 +200,11 @@ func (r *JobReconciler) deleteChart(ctx context.Context, job *ketchv1.Job) error
 		}
 
 		if uninstallHelmChart(ketchv1.Group, job.Annotations) {
-			helmClient, err := r.HelmFactoryFn(framework.Spec.NamespaceName)
+			targetNamespace := framework.Spec.NamespaceName
+			if job.Spec.Namespace != "" {
+				targetNamespace = job.Spec.Namespace
+			}
+			helmClient, err := r.HelmFactoryFn(targetNamespace)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

Permits overriding an App's namespace. Apps default to the namespace specified by `framework.spec.namespace`, but there are cases where we don't want namespace tied to framework.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
