### PR TITLE
[PLAY-648] Multi platform images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,169 @@
+name: build
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - "v*.*.*"
+    branches:
+      - "dev*"
+      - "main"
+  schedule:
+    - cron: "0 0 * * 1"
+
+env:
+  REGISTRY_IMAGE: shipasoftware/ketch
+
+jobs:
+  build-single-platform:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SHIPA_GITHUB_TOKEN }}
+          submodules: recursive
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          push: ${{ github.event_name != 'schedule' }}
+          tags: ${{ env.REGISTRY_IMAGE }}:${{ github.sha }}
+          build-args: |
+            github_user=${{ secrets.SHIPA_GITHUB_USERNAME }}
+            github_token=${{ secrets.SHIPA_GITHUB_TOKEN }}
+            release_version=${{ github.head_ref }}
+            git_commit=${{ github.sha }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.SHIPA_GITHUB_TOKEN }}
+  build-multiplatform:
+    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'schedule') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          #          - linux/riscv64
+          - linux/ppc64le
+          - linux/s390x
+          #          - linux/386 - no distroless support
+          #          - linux/mips64le - no distroless support
+          #          - linux/mips64 - no distroless support
+          - linux/arm/v7
+    #          - linux/arm/v6 - no distroless support
+    timeout-minutes: 30
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SHIPA_GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.SSH_KEY }}
+          submodules: recursive
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: type=raw,value=${{ github.sha }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            github_user=${{ secrets.SHIPA_GITHUB_USERNAME }}
+            github_token=${{ secrets.SHIPA_GITHUB_TOKEN }}
+            release_version=${{ github.head_ref }}
+            git_commit=${{ github.sha }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.SHIPA_GITHUB_TOKEN }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-multiplatform
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: type=raw,value=${{ github.sha }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+  security-scan:
+    runs-on: ubuntu-latest
+    needs:
+      - build-single-platform
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@f78e9ecf42a1271402d4f484518b9313235990e1
+        with:
+          image-ref: ${{ env.REGISTRY_IMAGE }}:${{ github.sha }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          exit-code: "1"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: deploy
+name: test
 
 on:
   push:
@@ -109,34 +109,3 @@ jobs:
         run: |
           cli_tests/job.sh
           cli_tests/app.sh
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          tags: shipasoftware/ketch:${{github.sha}}
-          push: true
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@f78e9ecf42a1271402d4f484518b9313235990e1
-        with:
-          image-ref: shipasoftware/ketch:${{ github.sha }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-          exit-code: "1"
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Idea is to build multiplatform image, but since cross platform building ARM64 image is really slow (20mins) we will also build old way.

jobs:
- **build-single-platform** - it's old way of building images (no qemu/buildx)
this job runs on PR requests, dev* branch, and also master branch
it is fast, and it will be first to built and pushed to docker hub, so that image that works for most situations is available quickly.
- trivy security scans, wait for **build-single-platform** to complete, and run security scan based on that. It also triggers on schedule, and uses that image

- **build-multiplatform** - this is new really slow way of building image
this job runs only on master
it is slow, and it will overwrite **build-single-platform** image once it completes. It should work for all distributions
**merge** waits for **build-multiplatform** job and it combines all platforms into single tag

pipeline:
<img width="741" alt="image" src="https://github.com/shipa-corp/shipa-agent/assets/6137163/f6cb27d3-a78a-40d4-9db2-e403f4e7048c">

single platform image (old) - pushed first
![image](https://github.com/shipa-corp/shipa-agent/assets/6137163/33a1ebc8-a40d-4ed8-84b3-96c3d5b02b25)

multi platform image(new) - which overwrites single platform image when it's built from main branch
![image](https://github.com/shipa-corp/shipa-agent/assets/6137163/52cda160-4be7-44e6-960b-efd95f5f93da)


