### PR TITLE
Build platform independant go binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY Makefile /go/src/github.com/theketchio/ketch/
 
 # Build
 RUN make generate
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/manager/main.go
+RUN CGO_ENABLED=0 go build -a -o manager cmd/manager/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
# Description

tested on minikube --driver=qemu on M1 mach, arm64, image is pulled succesfully, but binary fails to run with error
```
exec /bin/agent: exec format error
```

this should fix it

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

